### PR TITLE
Create dedicated roadmap view and refresh navigation

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -2,6 +2,7 @@
 import React from 'react';
 import { HashRouter, Routes, Route, Navigate } from 'react-router-dom';
 import JobSkillsMatcher from './components/JobSkillsMatcher';
+import CareerRoadmap from './components/CareerRoadmap';
 import JobExplorerGame from './components/JobExplorerGame';
 import GamesHub from './components/GamesHub';
 import GuessRoleGame from './components/GuessRoleGame';
@@ -14,12 +15,19 @@ export default function App(){
     <HashRouter>
       <Routes>
         <Route path="/" element={<JobSkillsMatcher/>} />
-        <Route path="/game" element={<JobExplorerGame/>} />
-        <Route path="/games" element={<GamesHub/>} />
-        <Route path="/games/guess-role" element={<GuessRoleGame/>} />
-        <Route path="/games/skill-quiz" element={<SkillDefinitionQuiz/>} />
-        <Route path="/games/career-board" element={<CareerBoardGame/>} />
-        <Route path="/games/pathway-matrix" element={<PathwayMatrixBoard/>} />
+        <Route path="/roadmap" element={<CareerRoadmap/>} />
+        <Route path="/play-lab" element={<GamesHub/>} />
+        <Route path="/play-lab/guess-skill" element={<JobExplorerGame/>} />
+        <Route path="/play-lab/guess-role" element={<GuessRoleGame/>} />
+        <Route path="/play-lab/skill-quiz" element={<SkillDefinitionQuiz/>} />
+        <Route path="/play-lab/career-board" element={<CareerBoardGame/>} />
+        <Route path="/play-lab/pathway-matrix" element={<PathwayMatrixBoard/>} />
+        <Route path="/game" element={<Navigate to="/play-lab/guess-skill" replace />} />
+        <Route path="/games" element={<Navigate to="/play-lab" replace />} />
+        <Route path="/games/guess-role" element={<Navigate to="/play-lab/guess-role" replace />} />
+        <Route path="/games/skill-quiz" element={<Navigate to="/play-lab/skill-quiz" replace />} />
+        <Route path="/games/career-board" element={<Navigate to="/play-lab/career-board" replace />} />
+        <Route path="/games/pathway-matrix" element={<Navigate to="/play-lab/pathway-matrix" replace />} />
         <Route path="*" element={<Navigate to="/" replace />} />
       </Routes>
     </HashRouter>

--- a/src/components/CareerBoardGame.jsx
+++ b/src/components/CareerBoardGame.jsx
@@ -196,8 +196,6 @@ export default function CareerBoardGame() {
     return () => window.removeEventListener('resize', updateCols);
   }, []);
 
-  const cells = boardJobs.length;
-  const rows = Math.max(1, Math.ceil(cells / cols));
   const indexToGrid = (i) => {
     const r = Math.floor(i / cols);
     const cInRow = i % cols;
@@ -269,7 +267,7 @@ export default function CareerBoardGame() {
                 </div>
               </div>
               <div className="row gap-12 align-center">
-                <Link to="/games" className="btn">Games Hub</Link>
+                <Link to="/play-lab" className="btn">Games Hub</Link>
                 <Link to="/" className="btn">
                   <Home className="icon-xs mr-6" /> Explorer
                 </Link>

--- a/src/components/CareerRoadmap.jsx
+++ b/src/components/CareerRoadmap.jsx
@@ -1,0 +1,431 @@
+// src/components/CareerRoadmap.jsx
+import React, { useEffect, useMemo, useState } from 'react';
+import { Link, useLocation } from 'react-router-dom';
+import {
+  Route as RouteIcon,
+  Home,
+  Gamepad2,
+  MapPin,
+  Users,
+  Filter,
+  CheckCircle,
+  AlertCircle,
+  XCircle,
+  BookOpen,
+} from 'lucide-react';
+import useJobDataset from '../hooks/useJobDataset';
+import {
+  alignVectors,
+  classifyType,
+  getTrainingRecommendations,
+} from '../utils/jobDataUtils';
+import './job-skills-matcher.css';
+
+const RoadmapDetails = ({ currentJob, targetJob }) => {
+  const [va, vb, names] = useMemo(
+    () => (currentJob && targetJob ? alignVectors(currentJob, targetJob) : [[], [], []]),
+    [currentJob, targetJob]
+  );
+
+  const typeByName = useMemo(() => {
+    const map = {};
+    names.forEach((n) => {
+      const tRaw = targetJob?.skillTypeByName?.[n] ?? currentJob?.skillTypeByName?.[n] ?? '';
+      map[n] = classifyType(tRaw);
+    });
+    return map;
+  }, [names, currentJob, targetJob]);
+
+  const groups = useMemo(() => {
+    const g = { similar: [], fair: [], needWork: [] };
+
+    names.forEach((n, i) => {
+      const cur = va[i] ?? 0;
+      const tar = vb[i] ?? 0;
+
+      if (tar <= cur) {
+        g.similar.push({ name: n, current: cur, target: tar, gap: 0 });
+        return;
+      }
+
+      const posGap = tar - cur;
+      const item = { name: n, current: cur, target: tar, gap: posGap };
+
+      if (posGap <= 1) g.similar.push(item);
+      else if (posGap <= 2) g.fair.push(item);
+      else g.needWork.push(item);
+    });
+
+    return g;
+  }, [va, vb, names]);
+
+  const groupsByType = useMemo(() => {
+    const mk = () => ({ similar: [], fair: [], needWork: [] });
+    const out = { functional: mk(), soft: mk(), unknown: mk() };
+    const add = (bucket, arr) => {
+      arr.forEach((s) => {
+        const t = typeByName[s.name] || 'unknown';
+        out[t][bucket].push({ ...s, type: t });
+      });
+    };
+    add('similar', groups.similar);
+    add('fair', groups.fair);
+    add('needWork', groups.needWork);
+    return out;
+  }, [groups, typeByName]);
+
+  const Group = ({ title, icon, color, items }) => {
+    if (!items.length) return null;
+    return (
+      <div className={`panel panel-${color}`}>
+        <h3 className="panel-title">
+          {icon}
+          {title} ({items.length})
+        </h3>
+        <div className="grid-two">
+          {items.map((s, i) => {
+            const recs = getTrainingRecommendations(
+              s.name,
+              s.type || typeByName[s.name] || '',
+              Math.abs(s.gap)
+            );
+            return (
+              <div key={i} className={`card border-${color}`}>
+                <div className="row space-between align-center mb-8">
+                  <h4 className="text-600">{s.name}</h4>
+                  <div className="row gap-8 text-sm">
+                    <span className={`text-${color}`}>Current: {s.current}/5</span>
+                    <span className="muted" aria-hidden="true">
+                      to
+                    </span>
+                    <span className="text-blue">Target: {s.target}/5</span>
+                  </div>
+                </div>
+                <div className="mb-8">
+                  <div className={`text-xs text-${color} mb-4`}>
+                    Gap: {s.gap > 0 ? '+' : ''}
+                    {s.gap} levels
+                  </div>
+                  <div className="bar">
+                    <div
+                      className={`bar-fill ${color}`}
+                      style={{ width: (s.current / 5) * 100 + '%' }}
+                    >
+                      <div
+                        className={`bar-planned ${color}`}
+                        style={{ width: Math.max(0, ((s.target - s.current) / 5) * 100) + '%' }}
+                      />
+                    </div>
+                  </div>
+                </div>
+                <div>
+                  <div className="text-sm muted mb-8">Recommended training:</div>
+                  {recs.map((t, idx) => (
+                    <div key={idx} className="row text-xs muted">
+                      <BookOpen className={`icon-xs mr-6 text-${color}`} />
+                      {t}
+                    </div>
+                  ))}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    );
+  };
+
+  if (!currentJob || !targetJob) return null;
+
+  return (
+    <div className="card" style={{ padding: 16 }}>
+      <div className="row align-center gap-12 mb-16">
+        <RouteIcon className="icon-sm" />
+        <h2 className="title-md">Career Transition Roadmap</h2>
+      </div>
+
+      <div className="panel">
+        <div className="row space-between">
+          <div>
+            <div className="text-sm muted">Current</div>
+            <div className="text-600">{currentJob.title}</div>
+          </div>
+          <div>
+            <div className="text-sm muted">Target</div>
+            <div className="text-600">{targetJob.title}</div>
+          </div>
+        </div>
+      </div>
+
+      <div className="panel">
+        <h3 className="panel-title">Functional Skills</h3>
+        <Group
+          title="Already Strong"
+          icon={<CheckCircle className="icon-sm mr-8" />}
+          color="green"
+          items={groupsByType.functional.similar}
+        />
+        <Group
+          title="Needs Some Development"
+          icon={<AlertCircle className="icon-sm mr-8" />}
+          color="yellow"
+          items={groupsByType.functional.fair}
+        />
+        <Group
+          title="Needs Significant Development"
+          icon={<XCircle className="icon-sm mr-8" />}
+          color="red"
+          items={groupsByType.functional.needWork}
+        />
+      </div>
+
+      <div className="panel">
+        <h3 className="panel-title">Soft Skills</h3>
+        <Group
+          title="Already Strong"
+          icon={<CheckCircle className="icon-sm mr-8" />}
+          color="green"
+          items={groupsByType.soft.similar}
+        />
+        <Group
+          title="Needs Some Development"
+          icon={<AlertCircle className="icon-sm mr-8" />}
+          color="yellow"
+          items={groupsByType.soft.fair}
+        />
+        <Group
+          title="Needs Significant Development"
+          icon={<XCircle className="icon-sm mr-8" />}
+          color="red"
+          items={groupsByType.soft.needWork}
+        />
+      </div>
+
+      {(groupsByType.unknown.similar.length ||
+        groupsByType.unknown.fair.length ||
+        groupsByType.unknown.needWork.length) > 0 && (
+        <div className="panel">
+          <h3 className="panel-title">Other Skills</h3>
+          <Group
+            title="Already Strong"
+            icon={<CheckCircle className="icon-sm mr-8" />}
+            color="green"
+            items={groupsByType.unknown.similar}
+          />
+          <Group
+            title="Needs Some Development"
+            icon={<AlertCircle className="icon-sm mr-8" />}
+            color="yellow"
+            items={groupsByType.unknown.fair}
+          />
+          <Group
+            title="Needs Significant Development"
+            icon={<XCircle className="icon-sm mr-8" />}
+            color="red"
+            items={groupsByType.unknown.needWork}
+          />
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default function CareerRoadmap() {
+  const { jobs, divisions, ready } = useJobDataset();
+  const location = useLocation();
+  const { currentTitle: stateCurrentTitle = '', targetTitle: stateTargetTitle = '' } =
+    location.state || {};
+
+  const [plannerDivision, setPlannerDivision] = useState('all');
+  const [plannerCurrentTitle, setPlannerCurrentTitle] = useState('');
+  const [plannerTargetTitle, setPlannerTargetTitle] = useState('');
+  const [myPositionTitle] = useState(() => {
+    if (typeof window === 'undefined') return '';
+    return window.localStorage.getItem('eva-my-position') || '';
+  });
+
+  useEffect(() => {
+    if (stateCurrentTitle) {
+      setPlannerCurrentTitle(stateCurrentTitle);
+    } else if (!plannerCurrentTitle && myPositionTitle) {
+      setPlannerCurrentTitle(myPositionTitle);
+    }
+  }, [stateCurrentTitle, myPositionTitle, plannerCurrentTitle]);
+
+  useEffect(() => {
+    if (stateTargetTitle) {
+      setPlannerTargetTitle(stateTargetTitle);
+    }
+  }, [stateTargetTitle]);
+
+  const myPosition = useMemo(
+    () => jobs.find((j) => j.title === myPositionTitle) || null,
+    [jobs, myPositionTitle]
+  );
+
+  const plannerJobsFiltered = useMemo(() => {
+    if (plannerDivision === 'all') return jobs;
+    return jobs.filter((j) => j.division === plannerDivision);
+  }, [jobs, plannerDivision]);
+
+  const plannerCurrentJob = useMemo(
+    () => jobs.find((j) => j.title === plannerCurrentTitle) || null,
+    [jobs, plannerCurrentTitle]
+  );
+
+  const plannerTargetJob = useMemo(
+    () => jobs.find((j) => j.title === plannerTargetTitle) || null,
+    [jobs, plannerTargetTitle]
+  );
+
+  const hasSelection = plannerCurrentJob && plannerTargetJob;
+
+  return (
+    <div className="page solid-bg">
+      <div className="topbar">
+        <div className="container">
+          <div className="row space-between align-center wrap">
+            <div className="row align-center gap-12">
+              <RouteIcon className="icon-md" />
+              <div>
+                <h1 className="brand-title">Explorer Roadmap</h1>
+                <p className="brand-sub muted">Merck Career Framework Planning</p>
+              </div>
+            </div>
+            <div className="row gap-12 align-center">
+              <Link to="/" className="btn">
+                <Home className="icon-xs mr-6" /> Explore Careers
+              </Link>
+              <Link to="/play-lab" className="btn ghost">
+                <Gamepad2 className="icon-xs mr-6" /> Play Lab
+              </Link>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="container content">
+        <div className="card section" style={{ marginBottom: 16 }}>
+          <div className="row space-between align-start wrap" style={{ gap: 16 }}>
+            <div className="column gap-8" style={{ flex: 1, minWidth: 260 }}>
+              <h2 className="section-h2" style={{ marginTop: 0 }}>
+                Plot your next move
+              </h2>
+              <p className="muted text-sm">
+                Choose the role you are in today and the role you aspire to. The roadmap highlights the
+                functional and soft skill shifts required to make the transition.
+              </p>
+              {myPosition && (
+                <div className="hero-status-card" style={{ marginTop: 12 }}>
+                  <div className="status-icon" aria-hidden="true">
+                    <MapPin className="icon-sm" />
+                  </div>
+                  <div>
+                    <div className="status-label">Saved starting role</div>
+                    <div className="status-value">{myPosition.title}</div>
+                  </div>
+                  <Link to="/" className="btn ghost small">
+                    Update
+                  </Link>
+                </div>
+              )}
+            </div>
+            <div className="column gap-8" style={{ minWidth: 260, maxWidth: 320 }}>
+              <div className="panel" style={{ margin: 0 }}>
+                <div className="panel-title row align-center">
+                  <Users className="icon-sm mr-8" /> Quick tips
+                </div>
+                <ul className="list text-sm muted" style={{ paddingLeft: 16, margin: 0 }}>
+                  <li>Use the function filter to narrow options.</li>
+                  <li>Swap targets anytime to compare different missions.</li>
+                  <li>
+                    Save your current role from the Explore Careers page for faster prefill in the planner.
+                  </li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div className="card section" style={{ marginBottom: 16 }}>
+          <div className="toolbar-grid" style={{ marginBottom: 16 }}>
+            <div className="field">
+              <label className="text-sm muted">Filter by Function</label>
+              <div className="relative">
+                <Filter className="icon-sm muted abs-left" />
+                <select
+                  className="input pl"
+                  value={plannerDivision}
+                  onChange={(e) => {
+                    setPlannerDivision(e.target.value);
+                    setPlannerCurrentTitle('');
+                    setPlannerTargetTitle('');
+                  }}
+                >
+                  <option value="all">All Functions</option>
+                  {divisions.map((d) => (
+                    <option key={d} value={d}>
+                      {d}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            </div>
+            <div className="field" />
+          </div>
+
+          <div className="grid-two">
+            <div className="column gap-8">
+              <label className="text-sm muted">Current Role</label>
+              <select
+                className="input"
+                value={plannerCurrentTitle}
+                onChange={(e) => setPlannerCurrentTitle(e.target.value)}
+              >
+                <option value="">
+                  {myPosition ? `My Position: ${myPosition.title}` : 'Select current role...'}
+                </option>
+                {plannerJobsFiltered.map((j) => (
+                  <option key={j.id} value={j.title}>
+                    {j.title} - {j.division}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            <div className="column gap-8">
+              <label className="text-sm muted">Target Role</label>
+              <select
+                className="input"
+                value={plannerTargetTitle}
+                onChange={(e) => setPlannerTargetTitle(e.target.value)}
+              >
+                <option value="">Select target role...</option>
+                {plannerJobsFiltered.map((j) => (
+                  <option key={j.id} value={j.title}>
+                    {j.title} - {j.division}
+                  </option>
+                ))}
+              </select>
+            </div>
+          </div>
+        </div>
+
+        {hasSelection ? (
+          <RoadmapDetails currentJob={plannerCurrentJob} targetJob={plannerTargetJob} />
+        ) : (
+          <div className="empty" style={{ padding: 16 }}>
+            {ready ? (
+              <p className="muted">
+                Pick both a current and a target role to see the roadmap insights.
+              </p>
+            ) : (
+              <p className="muted">Loading roles from the career framework...</p>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+

--- a/src/components/GamesHub.jsx
+++ b/src/components/GamesHub.jsx
@@ -14,7 +14,7 @@ export default function GamesHub() {
             <div className="row align-center gap-12">
               <Gamepad2 className="icon-md" />
               <div>
-                <h1 className="brand-title">SPH Play Lab</h1>
+                <h1 className="brand-title">Merck Career Framework Play Lab</h1>
                 <p className="brand-sub muted">Prototype missions built with today's data</p>
               </div>
             </div>
@@ -46,7 +46,7 @@ export default function GamesHub() {
               <p className="text-xs muted mb-8">
                 For the displayed role, pick the correct skill from multiple choices. Quick rounds to build familiarity.
               </p>
-              <Link to="/game" className="btn primary full row center">
+              <Link to="/play-lab/guess-skill" className="btn primary full row center">
                 Play
               </Link>
             </div>
@@ -62,7 +62,7 @@ export default function GamesHub() {
               <p className="text-xs muted mb-8">
                 See top skills and the function; choose which role they describe. Great for learning role signatures.
               </p>
-              <Link to="/games/guess-role" className="btn primary full row center">
+              <Link to="/play-lab/guess-role" className="btn primary full row center">
                 Play
               </Link>
             </div>
@@ -78,7 +78,7 @@ export default function GamesHub() {
               <p className="text-xs muted mb-8">
                 Read a skill definition and pick the correct skill name. Sharpens vocabulary and expectations.
               </p>
-              <Link to="/games/skill-quiz" className="btn primary full row center">
+              <Link to="/play-lab/skill-quiz" className="btn primary full row center">
                 Play
               </Link>
             </div>
@@ -94,7 +94,7 @@ export default function GamesHub() {
               <p className="text-xs muted mb-8">
                 Follow a board-style path of roles to see how careers progress within a function. Roll to advance and view key skills at each step.
               </p>
-              <Link to="/games/career-board" className="btn primary full row center">
+              <Link to="/play-lab/career-board" className="btn primary full row center">
                 Play
               </Link>
             </div>
@@ -110,7 +110,7 @@ export default function GamesHub() {
               <p className="text-xs muted mb-8">
                 A grid of origin vs landing clusters. Roll or click to explore allowed transitions and see example roles in the destination.
               </p>
-              <Link to="/games/pathway-matrix" className="btn primary full row center">
+              <Link to="/play-lab/pathway-matrix" className="btn primary full row center">
                 Play
               </Link>
             </div>

--- a/src/components/GuessRoleGame.jsx
+++ b/src/components/GuessRoleGame.jsx
@@ -167,7 +167,7 @@ export default function GuessRoleGame() {
               </div>
             </div>
             <div className="row gap-12 align-center">
-              <Link to="/games" className="btn">
+              <Link to="/play-lab" className="btn">
                 Back to Games
               </Link>
               <Link to="/" className="btn">
@@ -197,7 +197,7 @@ export default function GuessRoleGame() {
               <p className="muted">Your score: {score} / {TOTAL_ROUNDS}</p>
               <div className="row gap-12">
                 <button className="btn primary" onClick={resetGame}>Play Again</button>
-                <Link to="/games" className="btn">Games Hub</Link>
+                <Link to="/play-lab" className="btn">Games Hub</Link>
               </div>
             </div>
           )}

--- a/src/components/JobExplorerGame.jsx
+++ b/src/components/JobExplorerGame.jsx
@@ -190,7 +190,7 @@ export default function JobExplorerGame() {
               </div>
             </div>
             <div className="row gap-12 align-center">
-              <Link to="/games" className="btn">Games Hub</Link>
+              <Link to="/play-lab" className="btn">Games Hub</Link>
               <Link to="/" className="btn">
                 <Home className="icon-xs mr-6" /> Back to Explorer
               </Link>

--- a/src/components/PathwayMatrixBoard.jsx
+++ b/src/components/PathwayMatrixBoard.jsx
@@ -278,7 +278,7 @@ export default function PathwayMatrixBoard() {
             if (list.length) {
               list.sort();
               setClusters(list);
-              if (!list.includes(origin)) setOrigin(list[0]);
+              setOrigin((prev) => (list.includes(prev) ? prev : list[0]));
             }
           }
         } catch (e) {
@@ -365,7 +365,7 @@ export default function PathwayMatrixBoard() {
               </div>
             </div>
             <div className="row gap-12 align-center">
-              <Link to="/games" className="btn">Games Hub</Link>
+              <Link to="/play-lab" className="btn">Games Hub</Link>
               <Link to="/" className="btn">
                 <Home className="icon-xs mr-6" /> Explorer
               </Link>

--- a/src/components/SkillDefinitionQuiz.jsx
+++ b/src/components/SkillDefinitionQuiz.jsx
@@ -118,7 +118,7 @@ export default function SkillDefinitionQuiz() {
               </div>
             </div>
             <div className="row gap-12 align-center">
-              <Link to="/games" className="btn">Games Hub</Link>
+              <Link to="/play-lab" className="btn">Games Hub</Link>
               <Link to="/" className="btn"><Home className="icon-xs mr-6" /> Explorer</Link>
             </div>
           </div>
@@ -144,7 +144,7 @@ export default function SkillDefinitionQuiz() {
               <p className="muted">Your score: {score} / {TOTAL_ROUNDS}</p>
               <div className="row gap-12">
                 <button className="btn primary" onClick={resetGame}>Play Again</button>
-                <Link to="/games" className="btn">Games Hub</Link>
+                <Link to="/play-lab" className="btn">Games Hub</Link>
               </div>
             </div>
           )}

--- a/src/components/job-skills-matcher.css
+++ b/src/components/job-skills-matcher.css
@@ -52,6 +52,7 @@ body {
   color:var(--text);
   background:var(--bg);
   line-height: 1.6;
+  overflow-x: hidden;
 }
 
 /* =======================

--- a/src/hooks/useJobDataset.js
+++ b/src/hooks/useJobDataset.js
@@ -1,0 +1,35 @@
+// src/hooks/useJobDataset.js
+import { useEffect, useState } from 'react';
+import { parseCsvToJobs } from '../utils/jobDataUtils';
+
+export default function useJobDataset() {
+  const [jobs, setJobs] = useState([]);
+  const [divisions, setDivisions] = useState([]);
+  const [skillIDF, setSkillIDF] = useState({});
+  const [ready, setReady] = useState(false);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    let active = true;
+
+    parseCsvToJobs()
+      .then(({ jobs: parsedJobs, divisions: parsedDivisions, skillIDF: idf }) => {
+        if (!active) return;
+        setJobs(parsedJobs);
+        setDivisions(parsedDivisions);
+        setSkillIDF(idf);
+        setReady(true);
+      })
+      .catch((err) => {
+        if (!active) return;
+        setError(err);
+      });
+
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  return { jobs, divisions, skillIDF, ready, error };
+}
+

--- a/src/utils/jobDataUtils.js
+++ b/src/utils/jobDataUtils.js
@@ -1,0 +1,207 @@
+// src/utils/jobDataUtils.js
+import Papa from 'papaparse';
+
+export const CSV_URL = (process.env.PUBLIC_URL || '') + '/positions-skills.csv';
+
+export const normKey = (s) => String(s || '').trim();
+
+export function getCI(row, ...candidates) {
+  for (const c of candidates) {
+    for (const k of Object.keys(row)) {
+      if (k.toLowerCase() === c.toLowerCase()) {
+        const v = row[k];
+        return typeof v === 'string' ? v.trim() : v;
+      }
+    }
+  }
+  return '';
+}
+
+export const clamp01to5 = (n) => {
+  if (n < 0) return 0;
+  if (n > 5) return 5;
+  return n;
+};
+
+export function classifyType(typeRaw) {
+  const s = String(typeRaw || '').toLowerCase();
+  if (/functional/.test(s)) return 'functional';
+  if (/soft/.test(s)) return 'soft';
+  return 'unknown';
+}
+
+export function parseProficiency(row) {
+  const rawValue = getCI(row, 'Proficiency Value');
+  const rawLevel = getCI(row, 'Required Proficiency Level');
+
+  if (rawValue !== '') {
+    const n = Number(rawValue);
+    if (Number.isFinite(n)) return clamp01to5(n);
+  }
+  if (rawLevel !== '') {
+    const n = Number(rawLevel);
+    if (Number.isFinite(n)) return clamp01to5(n);
+    const s = rawLevel.toLowerCase();
+    if (/^none|not required$/.test(s)) return 0;
+    if (/^basic|beginner|familiar$/.test(s)) return 1;
+    if (/^low$/.test(s)) return 2;
+    if (/^intermediate|medium|moderate$/.test(s)) return 3;
+    if (/^advanced|high$/.test(s)) return 4;
+    if (/^expert|master$/.test(s)) return 5;
+  }
+  return 0;
+}
+
+export function alignVectors(jobA, jobB) {
+  const names = Array.from(
+    new Set([...(jobA?.skillOrder || []), ...(jobB?.skillOrder || [])])
+  );
+  const va = names.map((n) => jobA?.skillMap?.[n] ?? 0);
+  const vb = names.map((n) => jobB?.skillMap?.[n] ?? 0);
+  return [va, vb, names];
+}
+
+export function getTrainingRecommendations(skillName, typeOrGuess, gap) {
+  const soft = [
+    'Executive communication workshop',
+    'Stakeholder influence & negotiation',
+    'Cross-cultural collaboration',
+  ];
+  const functional = [
+    'Advanced domain certification',
+    'Tools & systems deep-dive',
+    'Mentored project-based learning',
+  ];
+  const pool = /soft/i.test(typeOrGuess) ? soft : functional;
+  const count = Math.min(3, Math.max(1, Math.ceil(gap || 1)));
+  return pool.slice(0, count);
+}
+
+export function transformRowsToJobs(rows) {
+  const byTitle = new Map();
+
+  rows.forEach((row) => {
+    const title = getCI(row, 'Core Position');
+    const division = getCI(row, 'Function');
+    const cluster = getCI(row, 'Core Position Cluster');
+    const clusterDef = getCI(row, 'Core Position Cluster Definition');
+    const objective = getCI(row, 'Core Position Main Objective');
+    const skillName = getCI(row, 'Skill');
+    const skillDef = getCI(row, 'Skill Definition');
+    const skillType = getCI(
+      row,
+      'Functional / Soft Skill',
+      'Functional/Soft Skill',
+      'Functional or Softskill?'
+    );
+    if (!title) return;
+
+    if (!byTitle.has(title)) {
+      byTitle.set(title, {
+        title,
+        division,
+        cluster,
+        clusterDef,
+        objective,
+        skillOrder: [],
+        skillMap: {},
+        skillDefByName: {},
+        skillTypeByName: {},
+      });
+    }
+    const job = byTitle.get(title);
+    job.division = job.division || division;
+    job.cluster = job.cluster || cluster;
+    job.clusterDef = job.clusterDef || clusterDef;
+    job.objective = job.objective || objective;
+
+    if (skillName) {
+      const level = parseProficiency(row);
+      if (!job.skillOrder.includes(skillName)) job.skillOrder.push(skillName);
+      job.skillMap[skillName] = Math.max(job.skillMap[skillName] || 0, level);
+      if (skillDef) job.skillDefByName[skillName] = skillDef;
+      if (skillType) job.skillTypeByName[skillName] = skillType;
+    }
+  });
+
+  let id = 1;
+  const jobs = Array.from(byTitle.values()).map((job) => {
+    const skills = job.skillOrder.map((s) => job.skillMap[s] ?? 0);
+    const description = job.objective
+      ? job.objective
+      : job.clusterDef
+      ? job.clusterDef
+      : `Responsibilities for ${job.title}.`;
+
+    return {
+      id: id++,
+      title: job.title,
+      division: job.division || 'Unknown Division',
+      skills,
+      skillOrder: job.skillOrder,
+      skillMap: job.skillMap,
+      skillDefByName: job.skillDefByName,
+      skillTypeByName: job.skillTypeByName,
+      description,
+      requirements: [],
+      cluster: job.cluster,
+      clusterDef: job.clusterDef,
+      objective: job.objective,
+    };
+  });
+
+  jobs.sort(
+    (a, b) =>
+      (a.division || '').localeCompare(b.division || '') ||
+      a.title.localeCompare(b.title)
+  );
+
+  return jobs;
+}
+
+export function computeSkillIDF(jobs) {
+  const N = jobs.length || 1;
+  const df = new Map();
+
+  jobs.forEach((job) => {
+    const seen = new Set(job.skillOrder || []);
+    seen.forEach((name) => df.set(name, (df.get(name) || 0) + 1));
+  });
+
+  const idfObj = {};
+  df.forEach((count, name) => {
+    const raw = 1 + Math.log((N + 1) / (count + 1));
+    idfObj[name] = Math.max(0.85, Math.min(1.35, raw));
+  });
+
+  return idfObj;
+}
+
+export function parseCsvToJobs() {
+  return new Promise((resolve, reject) => {
+    Papa.parse(CSV_URL, {
+      download: true,
+      header: true,
+      dynamicTyping: false,
+      skipEmptyLines: true,
+      complete: ({ data }) => {
+        const rows = (data || []).map((r) =>
+          Object.fromEntries(
+            Object.entries(r).map(([k, v]) => [
+              normKey(k),
+              typeof v === 'string' ? v.trim() : v,
+            ])
+          )
+        );
+        const jobs = transformRowsToJobs(rows);
+        resolve({
+          jobs,
+          divisions: Array.from(new Set(jobs.map((j) => j.division))),
+          skillIDF: computeSkillIDF(jobs),
+        });
+      },
+      error: (err) => reject(err),
+    });
+  });
+}
+


### PR DESCRIPTION
## Summary
- add a standalone Explorer Roadmap page with role selectors, training callouts, and shared CSV parsing utilities
- refactor the Explore Careers experience to use the shared dataset hook, link out to the roadmap page, and surface new Play Lab routing
- retheme navigation and game links around the three core pages and fix the body overflow that caused a double scrollbar

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c9396f6768832da3eef96b3757ad25