### PR TITLE
Style Play Lab game tiles as horizontal cards

### DIFF
--- a/src/components/CareerBoardGame.jsx
+++ b/src/components/CareerBoardGame.jsx
@@ -253,10 +253,10 @@ export default function CareerBoardGame() {
   }, [current, previous, topSkills]);
 
   return (
-    <div className="page solid-bg">
+    <div className="page solid-bg experience-page">
       <SiteHeader />
 
-      <div className="container content">
+      <div className="container content experience-content">
         <div className="page-heading">
           <div className="page-heading-main">
             <div className="page-heading-icon" aria-hidden="true">
@@ -274,7 +274,7 @@ export default function CareerBoardGame() {
           </div>
         </div>
 
-        <div className="card section" style={{ marginBottom: 16 }}>
+        <div className="card section">
           {/* Controls */}
           <div className="toolbar-grid" style={{ marginBottom: 16 }}>
             <div className="field">
@@ -314,14 +314,30 @@ export default function CareerBoardGame() {
           </div>
 
           {/* Scoreboard */}
-          <div className="row space-between align-center wrap mb-12">
-            <div className="row align-center gap-12">
-              <Trophy className="icon-sm yellow" />
-              <div className="text-sm">
-                Progress: <span className="text-600">{Math.min(position + 1, boardJobs.length)} / {boardJobs.length || 0}</span>
+          <div className="stat-strip">
+            <div className="stat-strip__item">
+              <span className="stat-icon stat-icon--gold">
+                <Trophy className="icon-sm" />
+              </span>
+              <div>
+                <div className="stat-label">Progress</div>
+                <div className="stat-value">
+                  {Math.min(position + 1, boardJobs.length)}
+                  <span className="stat-divider">/</span>
+                  <span className="stat-total">{boardJobs.length || 0}</span>
+                </div>
               </div>
             </div>
-            <div className="text-sm muted">Turn {turn} / {MAX_TURNS}</div>
+            <div className="stat-strip__item stat-strip__item--muted">
+              <div>
+                <div className="stat-label">Turn</div>
+                <div className="stat-value">
+                  {turn}
+                  <span className="stat-divider">/</span>
+                  <span className="stat-total">{MAX_TURNS}</span>
+                </div>
+              </div>
+            </div>
           </div>
 
           {/* Board (serpentine grid) */}

--- a/src/components/CareerRoadmap.jsx
+++ b/src/components/CareerRoadmap.jsx
@@ -280,10 +280,10 @@ export default function CareerRoadmap() {
   const hasSelection = plannerCurrentJob && plannerTargetJob;
 
   return (
-    <div className="page solid-bg">
+    <div className="page solid-bg experience-page">
       <SiteHeader />
 
-      <div className="container content">
+      <div className="container content experience-content">
         <div className="page-heading">
           <div className="page-heading-main">
             <div className="page-heading-icon" aria-hidden="true">
@@ -296,7 +296,7 @@ export default function CareerRoadmap() {
           </div>
         </div>
 
-        <div className="card section" style={{ marginBottom: 16 }}>
+        <div className="card section">
           <div className="row space-between align-start wrap" style={{ gap: 16 }}>
             <div className="column gap-8" style={{ flex: 1, minWidth: 260 }}>
               <h2 className="section-h2" style={{ marginTop: 0 }}>
@@ -338,7 +338,7 @@ export default function CareerRoadmap() {
           </div>
         </div>
 
-        <div className="card section" style={{ marginBottom: 16 }}>
+        <div className="card section">
           <div className="toolbar-grid" style={{ marginBottom: 16 }}>
             <div className="field">
               <label className="text-sm muted">Filter by Function</label>

--- a/src/components/GamesHub.jsx
+++ b/src/components/GamesHub.jsx
@@ -7,10 +7,10 @@ import SiteHeader from './SiteHeader';
 
 export default function GamesHub() {
   return (
-    <div className="page solid-bg">
+    <div className="page solid-bg experience-page">
       <SiteHeader />
 
-      <div className="container content">
+      <div className="container content experience-content">
         <div className="page-heading">
           <div className="page-heading-main">
             <div className="page-heading-icon" aria-hidden="true">
@@ -23,91 +23,106 @@ export default function GamesHub() {
           </div>
         </div>
 
-        <div className="card section" style={{ marginBottom: 16 }}>
+        <div className="card section">
           <p className="hero-footnote" style={{ marginTop: 0 }}>
             These playful experiments reflect the game concepts we can build with the information available
             today. Expect the Play Lab to grow livelier as the SPH dataset uncovers more insights.
           </p>
-          <div className="grid-cards">
+          <div className="play-lab-grid">
             {/* Game: Job Explorer (guess a skill) */}
-            <div className="match match-good">
-              <div className="row space-between mb-6">
-                <h4 className="text-sm text-600 row align-center">
-                  <ListChecks className="icon-sm mr-8" /> Guess a Skill
-                </h4>
-                <span className="badge">Beginner</span>
+            <article className="match match-good play-lab-card">
+              <div className="play-lab-card-icon" aria-hidden="true">
+                <ListChecks className="icon-md" />
               </div>
-              <p className="text-xs muted mb-8">
-                For the displayed role, pick the correct skill from multiple choices. Quick rounds to build familiarity.
-              </p>
-              <Link to="/play-lab/guess-skill" className="btn primary full row center">
+              <div className="play-lab-card-content">
+                <div className="play-lab-card-heading">
+                  <h3 className="play-lab-card-title">Guess a Skill</h3>
+                  <span className="badge">Beginner</span>
+                </div>
+                <p className="play-lab-card-description text-xs muted">
+                  For the displayed role, pick the correct skill from multiple choices. Quick rounds to build familiarity.
+                </p>
+              </div>
+              <Link to="/play-lab/guess-skill" className="btn primary play-lab-card-cta">
                 Play
               </Link>
-            </div>
+            </article>
 
             {/* Game: Guess the Role */}
-            <div className="match match-fair">
-              <div className="row space-between mb-6">
-                <h4 className="text-sm text-600 row align-center">
-                  <Target className="icon-sm mr-8" /> Guess the Role
-                </h4>
-                <span className="badge solid yellow">Intermediate</span>
+            <article className="match match-fair play-lab-card">
+              <div className="play-lab-card-icon" aria-hidden="true">
+                <Target className="icon-md" />
               </div>
-              <p className="text-xs muted mb-8">
-                See top skills and the function; choose which role they describe. Great for learning role signatures.
-              </p>
-              <Link to="/play-lab/guess-role" className="btn primary full row center">
+              <div className="play-lab-card-content">
+                <div className="play-lab-card-heading">
+                  <h3 className="play-lab-card-title">Guess the Role</h3>
+                  <span className="badge solid yellow">Intermediate</span>
+                </div>
+                <p className="play-lab-card-description text-xs muted">
+                  See top skills and the function; choose which role they describe. Great for learning role signatures.
+                </p>
+              </div>
+              <Link to="/play-lab/guess-role" className="btn primary play-lab-card-cta">
                 Play
               </Link>
-            </div>
+            </article>
 
             {/* Game: Skill Definition Quiz */}
-            <div className="match match-excellent">
-              <div className="row space-between mb-6">
-                <h4 className="text-sm text-600 row align-center">
-                  <BookOpen className="icon-sm mr-8" /> Skill Definition Quiz
-                </h4>
-                <span className="badge solid green">Knowledge</span>
+            <article className="match match-excellent play-lab-card">
+              <div className="play-lab-card-icon" aria-hidden="true">
+                <BookOpen className="icon-md" />
               </div>
-              <p className="text-xs muted mb-8">
-                Read a skill definition and pick the correct skill name. Sharpens vocabulary and expectations.
-              </p>
-              <Link to="/play-lab/skill-quiz" className="btn primary full row center">
+              <div className="play-lab-card-content">
+                <div className="play-lab-card-heading">
+                  <h3 className="play-lab-card-title">Skill Definition Quiz</h3>
+                  <span className="badge solid green">Knowledge</span>
+                </div>
+                <p className="play-lab-card-description text-xs muted">
+                  Read a skill definition and pick the correct skill name. Sharpens vocabulary and expectations.
+                </p>
+              </div>
+              <Link to="/play-lab/skill-quiz" className="btn primary play-lab-card-cta">
                 Play
               </Link>
-            </div>
+            </article>
 
             {/* Game: Career Path Board */}
-            <div className="match match-good">
-              <div className="row space-between mb-6">
-                <h4 className="text-sm text-600 row align-center">
-                  <RouteIcon className="icon-sm mr-8" /> Career Path Board
-                </h4>
-                <span className="badge">Pathway</span>
+            <article className="match match-good play-lab-card">
+              <div className="play-lab-card-icon" aria-hidden="true">
+                <RouteIcon className="icon-md" />
               </div>
-              <p className="text-xs muted mb-8">
-                Follow a board-style path of roles to see how careers progress within a function. Roll to advance and view key skills at each step.
-              </p>
-              <Link to="/play-lab/career-board" className="btn primary full row center">
+              <div className="play-lab-card-content">
+                <div className="play-lab-card-heading">
+                  <h3 className="play-lab-card-title">Career Path Board</h3>
+                  <span className="badge">Pathway</span>
+                </div>
+                <p className="play-lab-card-description text-xs muted">
+                  Follow a board-style path of roles to see how careers progress within a function. Roll to advance and view key skills at each step.
+                </p>
+              </div>
+              <Link to="/play-lab/career-board" className="btn primary play-lab-card-cta">
                 Play
               </Link>
-            </div>
+            </article>
 
             {/* Game: Pathway Matrix Board */}
-            <div className="match match-fair">
-              <div className="row space-between mb-6">
-                <h4 className="text-sm text-600 row align-center">
-                  <Grid3x3 className="icon-sm mr-8" /> Pathway Matrix Board
-                </h4>
-                <span className="badge">Matrix</span>
+            <article className="match match-fair play-lab-card">
+              <div className="play-lab-card-icon" aria-hidden="true">
+                <Grid3x3 className="icon-md" />
               </div>
-              <p className="text-xs muted mb-8">
-                A grid of origin vs landing clusters. Roll or click to explore allowed transitions and see example roles in the destination.
-              </p>
-              <Link to="/play-lab/pathway-matrix" className="btn primary full row center">
+              <div className="play-lab-card-content">
+                <div className="play-lab-card-heading">
+                  <h3 className="play-lab-card-title">Pathway Matrix Board</h3>
+                  <span className="badge">Matrix</span>
+                </div>
+                <p className="play-lab-card-description text-xs muted">
+                  A grid of origin vs landing clusters. Roll or click to explore allowed transitions and see example roles in the destination.
+                </p>
+              </div>
+              <Link to="/play-lab/pathway-matrix" className="btn primary play-lab-card-cta">
                 Play
               </Link>
-            </div>
+            </article>
           </div>
         </div>
       </div>

--- a/src/components/GuessRoleGame.jsx
+++ b/src/components/GuessRoleGame.jsx
@@ -155,10 +155,10 @@ export default function GuessRoleGame() {
   }, [ready]);
 
   return (
-    <div className="page solid-bg">
+    <div className="page solid-bg experience-page">
       <SiteHeader />
 
-      <div className="container content">
+      <div className="container content experience-content">
         <div className="page-heading">
           <div className="page-heading-main">
             <div className="page-heading-icon" aria-hidden="true">
@@ -176,13 +176,27 @@ export default function GuessRoleGame() {
           </div>
         </div>
 
-        <div className="card section" style={{ marginBottom: 16 }}>
-          <div className="row space-between align-center wrap mb-12">
-            <div className="row align-center gap-12">
-              <Trophy className="icon-sm yellow" />
-              <div className="text-sm">Score: <span className="text-600">{score}</span></div>
+        <div className="card section">
+          <div className="stat-strip">
+            <div className="stat-strip__item">
+              <span className="stat-icon stat-icon--gold">
+                <Trophy className="icon-sm" />
+              </span>
+              <div>
+                <div className="stat-label">Score</div>
+                <div className="stat-value">{score}</div>
+              </div>
             </div>
-            <div className="text-sm muted">Round {Math.min(round, TOTAL_ROUNDS)} / {TOTAL_ROUNDS}</div>
+            <div className="stat-strip__item stat-strip__item--muted">
+              <div>
+                <div className="stat-label">Round</div>
+                <div className="stat-value">
+                  {Math.min(round, TOTAL_ROUNDS)}
+                  <span className="stat-divider">/</span>
+                  <span className="stat-total">{TOTAL_ROUNDS}</span>
+                </div>
+              </div>
+            </div>
           </div>
 
           {!ready && <div className="empty">Loading game data…</div>}

--- a/src/components/HomePage.jsx
+++ b/src/components/HomePage.jsx
@@ -1,5 +1,4 @@
 import React, { useRef } from 'react';
-import { Link } from 'react-router-dom';
 import '../styles/main.css';
 import SiteHeader from './SiteHeader';
 import HeroSection from './HeroSection';

--- a/src/components/JobExplorerGame.jsx
+++ b/src/components/JobExplorerGame.jsx
@@ -178,10 +178,10 @@ export default function JobExplorerGame() {
   }, [current]);
 
   return (
-    <div className="page solid-bg">
+    <div className="page solid-bg experience-page">
       <SiteHeader />
 
-      <div className="container content">
+      <div className="container content experience-content">
         <div className="page-heading">
           <div className="page-heading-main">
             <div className="page-heading-icon" aria-hidden="true">
@@ -199,13 +199,27 @@ export default function JobExplorerGame() {
           </div>
         </div>
 
-        <div className="card section" style={{ marginBottom: 16 }}>
-          <div className="row space-between align-center wrap mb-12">
-            <div className="row align-center gap-12">
-              <Trophy className="icon-sm yellow" />
-              <div className="text-sm">Score: <span className="text-600">{score}</span></div>
+        <div className="card section">
+          <div className="stat-strip">
+            <div className="stat-strip__item">
+              <span className="stat-icon stat-icon--gold">
+                <Trophy className="icon-sm" />
+              </span>
+              <div>
+                <div className="stat-label">Score</div>
+                <div className="stat-value">{score}</div>
+              </div>
             </div>
-            <div className="text-sm muted">Round {Math.min(round, TOTAL_ROUNDS)} / {TOTAL_ROUNDS}</div>
+            <div className="stat-strip__item stat-strip__item--muted">
+              <div>
+                <div className="stat-label">Round</div>
+                <div className="stat-value">
+                  {Math.min(round, TOTAL_ROUNDS)}
+                  <span className="stat-divider">/</span>
+                  <span className="stat-total">{TOTAL_ROUNDS}</span>
+                </div>
+              </div>
+            </div>
           </div>
 
           {!ready && <div className="empty">Loading game data…</div>}

--- a/src/components/JobSkillsMatcher.jsx
+++ b/src/components/JobSkillsMatcher.jsx
@@ -1,5 +1,5 @@
 // src/components/JobSkillsMatcher.jsx
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import {
   Search,
@@ -10,7 +10,6 @@ import {
   MapPin,
   Briefcase,
   Route,
-  Sparkles,
 } from 'lucide-react';
 import '../styles/main.css';
 import useJobDataset from '../hooks/useJobDataset';
@@ -46,13 +45,6 @@ const JobSkillsMatcher = () => {
 
   const [myPickerDivision, setMyPickerDivision] = useState('all');
   const [myPickerTitle, setMyPickerTitle] = useState('');
-
-  const myPositionRef = useRef(null);
-  const scrollToMyPosition = () => {
-    if (myPositionRef.current) {
-      myPositionRef.current.scrollIntoView({ behavior: 'smooth', block: 'start' });
-    }
-  };
 
   useEffect(() => {
     if (typeof window === 'undefined') return;
@@ -216,16 +208,12 @@ const JobSkillsMatcher = () => {
     setMyPositionTitle(myPickerTitle);
   };
 
-  const startingRoleMessage = myPosition
-    ? myPosition.title
-    : 'Set a home position in “My Position” to personalise your roadmap.';
-
   return (
-    <div className="page solid-bg">
+    <div className="page solid-bg experience-page">
       <SiteHeader />
 
       {/* Content */}
-      <div className="container content">
+      <div className="container content experience-content">
         <div className="page-heading">
           <div className="page-heading-main">
             <div className="page-heading-icon" aria-hidden="true">
@@ -243,9 +231,9 @@ const JobSkillsMatcher = () => {
         
 
         {/* ========== SECTION: My Position ========== */}
-        <section ref={myPositionRef}>
+        <section>
           <h2 className="section-h2">My Position</h2>
-          <div className="card section" style={{ marginBottom: 16 }}>
+          <div className="card section">
             <div className="toolbar-grid">
               <div className="field">
                 <label className="text-sm muted">Function</label>
@@ -340,7 +328,7 @@ const JobSkillsMatcher = () => {
           <>
             <h2 className="section-h2">Recommendations</h2>
             {recommendationsForMyPosition.length > 0 ? (
-              <div className="card section" style={{ marginBottom: 16 }}>
+              <div className="card section">
                 <div className="grid-cards">
                   {recommendationsForMyPosition.map((job) => {
                     const badge = getSimilarityBadge(job.similarity);

--- a/src/components/PathwayMatrixBoard.jsx
+++ b/src/components/PathwayMatrixBoard.jsx
@@ -353,10 +353,10 @@ export default function PathwayMatrixBoard() {
   };
 
   return (
-    <div className="page solid-bg">
+    <div className="page solid-bg experience-page">
       <SiteHeader />
 
-      <div className="container content">
+      <div className="container content experience-content">
         <div className="page-heading">
           <div className="page-heading-main">
             <div className="page-heading-icon" aria-hidden="true">
@@ -374,9 +374,9 @@ export default function PathwayMatrixBoard() {
           </div>
         </div>
 
-        <div className="card section" style={{ marginBottom: 16 }}>
+        <div className="card section">
           {/* Controls */}
-          <div className="row space-between align-center wrap mb-12">
+          <div className="row space-between align-center wrap mb-12 control-bar">
             <div className="row align-center gap-12">
               <div className="field" style={{ minWidth: 320 }}>
                 <label className="text-sm muted">Origin Cluster</label>

--- a/src/components/SkillDefinitionQuiz.jsx
+++ b/src/components/SkillDefinitionQuiz.jsx
@@ -106,10 +106,10 @@ export default function SkillDefinitionQuiz() {
   }, [ready]);
 
   return (
-    <div className="page solid-bg">
+    <div className="page solid-bg experience-page">
       <SiteHeader />
 
-      <div className="container content">
+      <div className="container content experience-content">
         <div className="page-heading">
           <div className="page-heading-main">
             <div className="page-heading-icon" aria-hidden="true">
@@ -127,13 +127,27 @@ export default function SkillDefinitionQuiz() {
           </div>
         </div>
 
-        <div className="card section" style={{ marginBottom: 16 }}>
-          <div className="row space-between align-center wrap mb-12">
-            <div className="row align-center gap-12">
-              <Trophy className="icon-sm yellow" />
-              <div className="text-sm">Score: <span className="text-600">{score}</span></div>
+        <div className="card section">
+          <div className="stat-strip">
+            <div className="stat-strip__item">
+              <span className="stat-icon stat-icon--gold">
+                <Trophy className="icon-sm" />
+              </span>
+              <div>
+                <div className="stat-label">Score</div>
+                <div className="stat-value">{score}</div>
+              </div>
             </div>
-            <div className="text-sm muted">Round {Math.min(round, TOTAL_ROUNDS)} / {TOTAL_ROUNDS}</div>
+            <div className="stat-strip__item stat-strip__item--muted">
+              <div>
+                <div className="stat-label">Round</div>
+                <div className="stat-value">
+                  {Math.min(round, TOTAL_ROUNDS)}
+                  <span className="stat-divider">/</span>
+                  <span className="stat-total">{TOTAL_ROUNDS}</span>
+                </div>
+              </div>
+            </div>
           </div>
 
           {!ready && <div className="empty">Loading skills…</div>}

--- a/src/styles/layouts/job-skills-matcher.css
+++ b/src/styles/layouts/job-skills-matcher.css
@@ -699,3 +699,485 @@ img, video { max-width:100%; height:auto; }
 .kind-other     { background: #f8f9fc; }
 .kind-empty     { background: #ffffff; }
 
+/* =======================
+   Experience pages polished visuals
+   ======================= */
+.experience-page {
+  position: relative;
+  background:
+    radial-gradient(120% 120% at 100% 0%, rgba(127, 77, 255, 0.14) 0%, transparent 52%),
+    radial-gradient(140% 140% at 0% 100%, rgba(255, 211, 77, 0.12) 0%, transparent 60%),
+    var(--bg);
+  overflow: hidden;
+}
+
+.experience-page::before,
+.experience-page::after {
+  content: '';
+  position: absolute;
+  border-radius: 50%;
+  pointer-events: none;
+  z-index: 0;
+}
+
+.experience-page::before {
+  width: 420px;
+  height: 420px;
+  top: -180px;
+  right: -140px;
+  background: radial-gradient(circle, rgba(127, 77, 255, 0.28) 0%, rgba(127, 77, 255, 0) 70%);
+  opacity: 0.6;
+}
+
+.experience-page::after {
+  width: 360px;
+  height: 360px;
+  bottom: -160px;
+  left: -120px;
+  background: radial-gradient(circle, rgba(255, 211, 77, 0.26) 0%, rgba(255, 211, 77, 0) 72%);
+  opacity: 0.55;
+}
+
+.experience-page .experience-content,
+.experience-page .container,
+.experience-page .content {
+  position: relative;
+  z-index: 1;
+}
+
+.experience-page .page-heading {
+  position: relative;
+  margin-bottom: 32px;
+  padding: 28px 32px;
+  border-radius: 28px;
+  border: 1px solid rgba(91, 46, 198, 0.14);
+  background: linear-gradient(135deg, rgba(127, 77, 255, 0.12) 0%, rgba(255, 247, 222, 0.58) 45%, rgba(255, 255, 255, 0.92) 100%);
+  box-shadow: 0 28px 64px rgba(31, 15, 61, 0.18);
+  overflow: hidden;
+}
+
+.experience-page .page-heading::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 85% 0%, rgba(127, 77, 255, 0.22), transparent 55%);
+  opacity: 0.6;
+  pointer-events: none;
+  z-index: 0;
+}
+
+.experience-page .page-heading > * {
+  position: relative;
+  z-index: 1;
+}
+
+.experience-page .page-heading-icon {
+  width: 64px;
+  height: 64px;
+  border-radius: 20px;
+  background: linear-gradient(135deg, var(--purple) 0%, #2d114f 100%);
+  color: #fff;
+  box-shadow: 0 18px 38px rgba(91, 46, 198, 0.3);
+}
+
+.experience-page .page-heading-title {
+  font-size: 2rem;
+  color: #160b34;
+}
+
+.experience-page .page-heading-subtitle {
+  font-size: 1rem;
+  color: rgba(31, 15, 61, 0.72);
+  max-width: 600px;
+}
+
+.experience-page .page-heading-actions .btn {
+  border-radius: 999px;
+}
+
+.experience-page .card.section {
+  position: relative;
+  padding: 26px 32px;
+  margin-bottom: 32px;
+  border-radius: 26px;
+  border: 1px solid rgba(91, 46, 198, 0.12);
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.96) 0%, rgba(244, 240, 255, 0.82) 100%);
+  box-shadow: 0 24px 60px rgba(31, 15, 61, 0.14);
+  backdrop-filter: blur(6px);
+  overflow: hidden;
+}
+
+.experience-page .card.section::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 15% -10%, rgba(255, 247, 222, 0.5), transparent 55%);
+  opacity: 0.6;
+  pointer-events: none;
+  z-index: 0;
+}
+
+.experience-page .card.section > * {
+  position: relative;
+  z-index: 1;
+}
+
+.experience-page .card.section:last-child {
+  margin-bottom: 0;
+}
+
+.experience-page .toolbar.card {
+  padding: 20px 24px;
+  border-radius: 24px;
+  border: 1px solid rgba(91, 46, 198, 0.1);
+  background: rgba(255, 255, 255, 0.82);
+  box-shadow: 0 16px 40px rgba(31, 15, 61, 0.12);
+}
+
+.experience-page .panel {
+  border-radius: 20px;
+  border: 1px solid rgba(91, 46, 198, 0.1);
+  background: rgba(255, 255, 255, 0.9);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.45);
+  padding: 18px 20px;
+}
+
+.experience-page .panel .panel {
+  border-radius: 16px;
+  background: rgba(244, 240, 255, 0.9);
+}
+
+.experience-page .grid-cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 20px;
+}
+
+.experience-page .match {
+  padding: 18px 20px;
+  border-radius: 20px;
+  border: 1px solid rgba(91, 46, 198, 0.12);
+  background: linear-gradient(155deg, rgba(255, 255, 255, 0.98) 0%, rgba(244, 240, 255, 0.9) 100%);
+  box-shadow: 0 20px 44px rgba(31, 15, 61, 0.12);
+  transition: transform 0.18s ease, box-shadow 0.18s ease;
+}
+
+.experience-page .match::before {
+  width: 6px;
+  border-top-left-radius: 20px;
+  border-bottom-left-radius: 20px;
+}
+
+.experience-page .match:hover {
+  transform: translateY(-3px);
+  box-shadow: 0 26px 52px rgba(31, 15, 61, 0.18);
+}
+
+.experience-page .badge {
+  background: rgba(244, 240, 255, 0.8);
+  border-color: rgba(91, 46, 198, 0.18);
+  color: var(--purple);
+}
+
+.experience-page .badge.solid.green {
+  background: rgba(56, 212, 167, 0.2);
+  border-color: rgba(56, 212, 167, 0.35);
+  color: #0f6b4f;
+}
+
+.experience-page .badge.solid.yellow {
+  background: rgba(255, 211, 77, 0.28);
+  border-color: rgba(255, 211, 77, 0.42);
+  color: #6f5200;
+}
+
+.experience-page .play-lab-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.experience-page .play-lab-card {
+  display: flex;
+  align-items: center;
+  gap: 20px;
+  padding: 22px 28px 22px 36px;
+  cursor: default;
+  flex-wrap: wrap;
+  row-gap: 12px;
+}
+
+.experience-page .play-lab-card-icon {
+  width: 58px;
+  height: 58px;
+  border-radius: 18px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(244, 240, 255, 0.85);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.45);
+  border: 1px solid rgba(91, 46, 198, 0.16);
+  color: var(--purple);
+  flex-shrink: 0;
+}
+
+.experience-page .match-good .play-lab-card-icon {
+  background: rgba(255, 211, 77, 0.28);
+  border-color: rgba(255, 211, 77, 0.35);
+  color: #6f5200;
+}
+
+.experience-page .match-excellent .play-lab-card-icon {
+  background: rgba(56, 212, 167, 0.24);
+  border-color: rgba(56, 212, 167, 0.32);
+  color: #0f6b4f;
+}
+
+.experience-page .match-fair .play-lab-card-icon {
+  background: rgba(127, 77, 255, 0.22);
+  border-color: rgba(91, 46, 198, 0.28);
+  color: var(--purple);
+}
+
+.experience-page .play-lab-card-content {
+  flex: 1 1 260px;
+  min-width: 220px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.experience-page .play-lab-card-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.experience-page .play-lab-card-heading .badge {
+  flex-shrink: 0;
+}
+
+.experience-page .play-lab-card-title {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 700;
+  color: var(--text);
+}
+
+.experience-page .play-lab-card-description {
+  margin: 0;
+  line-height: 1.55;
+  color: var(--muted);
+}
+
+.experience-page .play-lab-card-cta {
+  margin-left: auto;
+  flex: 0 0 auto;
+}
+
+@media (max-width: 720px) {
+  .experience-page .play-lab-card {
+    padding: 20px 24px 22px 32px;
+  }
+
+  .experience-page .play-lab-card-heading {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 10px;
+  }
+
+  .experience-page .play-lab-card-cta {
+    width: 100%;
+    margin-left: 0;
+  }
+}
+
+.experience-page .empty {
+  background: rgba(255, 255, 255, 0.85);
+  border-radius: 22px;
+  border: 1px dashed rgba(91, 46, 198, 0.2);
+  box-shadow: none;
+}
+
+.experience-page .hero-status-card {
+  background: rgba(255, 255, 255, 0.92);
+  border: 1px solid rgba(91, 46, 198, 0.12);
+  border-radius: 20px;
+  padding: 16px 20px;
+  box-shadow: 0 14px 36px rgba(31, 15, 61, 0.12);
+}
+
+.experience-page .status-icon {
+  background: linear-gradient(135deg, #38d4a7 0%, #1ea97c 100%);
+  color: #0a382a;
+}
+
+.experience-page .input {
+  border-radius: 14px;
+  border-color: rgba(91, 46, 198, 0.18);
+  background: rgba(255, 255, 255, 0.9);
+}
+
+.experience-page .input:focus {
+  border-color: var(--purple);
+  box-shadow: 0 0 0 4px rgba(127, 77, 255, 0.16);
+}
+
+.experience-page .bar {
+  background: rgba(234, 231, 250, 0.85);
+}
+
+.experience-page .board {
+  border-radius: 24px;
+  border: 1px solid rgba(91, 46, 198, 0.12);
+  background: rgba(255, 255, 255, 0.9);
+  padding: 12px 16px;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.5);
+}
+
+.experience-page .tile {
+  border-radius: 18px;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.96) 0%, rgba(245, 241, 255, 0.82) 100%);
+  border: 1px solid rgba(91, 46, 198, 0.12);
+  box-shadow: 0 14px 32px rgba(31, 15, 61, 0.1);
+}
+
+.experience-page .tile.active {
+  border-color: rgba(127, 77, 255, 0.85);
+  box-shadow: 0 18px 46px rgba(91, 46, 198, 0.28);
+}
+
+.experience-page .token {
+  background: linear-gradient(135deg, #38d4a7 0%, #13a375 100%);
+  border-color: rgba(0, 70, 48, 0.25);
+}
+
+.experience-page .matrix-grid {
+  border-radius: 18px;
+  border: 1px solid rgba(91, 46, 198, 0.12);
+  background: rgba(244, 240, 255, 0.7);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.7);
+}
+
+.experience-page .matrix-cell {
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.9);
+  border-color: rgba(91, 46, 198, 0.16);
+}
+
+.experience-page .matrix-cell.allowed:hover {
+  box-shadow: 0 18px 32px rgba(31, 15, 61, 0.18);
+}
+
+.stat-strip {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 20px;
+  padding: 18px 22px;
+  border-radius: 22px;
+  border: 1px solid rgba(91, 46, 198, 0.12);
+  background: rgba(255, 255, 255, 0.92);
+  box-shadow: 0 16px 40px rgba(31, 15, 61, 0.14);
+  flex-wrap: wrap;
+}
+
+.stat-strip__item {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.stat-strip__item--muted {
+  color: var(--muted);
+}
+
+.stat-label {
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(31, 15, 61, 0.58);
+}
+
+.stat-value {
+  font-size: 1.35rem;
+  font-weight: 700;
+  color: var(--text);
+}
+
+.stat-divider {
+  display: inline-flex;
+  align-items: center;
+  margin: 0 6px;
+  font-weight: 600;
+  color: rgba(100, 90, 130, 0.45);
+}
+
+.stat-total {
+  font-size: 1rem;
+  font-weight: 600;
+  color: rgba(31, 15, 61, 0.6);
+}
+
+.stat-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border-radius: 14px;
+  background: rgba(127, 77, 255, 0.14);
+  color: var(--purple);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
+}
+
+.stat-icon--gold {
+  background: rgba(255, 211, 77, 0.22);
+  color: #7a5400;
+}
+
+.control-bar {
+  padding: 18px 20px;
+  border-radius: 22px;
+  border: 1px solid rgba(91, 46, 198, 0.1);
+  background: rgba(255, 255, 255, 0.92);
+  box-shadow: 0 18px 42px rgba(31, 15, 61, 0.12);
+  gap: 20px;
+}
+
+.control-bar .btn {
+  border-radius: 999px;
+}
+
+@media (max-width: 768px) {
+  .experience-page .page-heading {
+    padding: 24px;
+    border-radius: 22px;
+  }
+
+  .experience-page .page-heading-icon {
+    width: 56px;
+    height: 56px;
+  }
+
+  .experience-page .page-heading-title {
+    font-size: 1.75rem;
+  }
+
+  .experience-page .card.section {
+    padding: 22px;
+    border-radius: 22px;
+  }
+
+  .stat-strip {
+    padding: 16px 18px;
+  }
+
+  .control-bar {
+    padding: 16px 18px;
+  }
+}
+


### PR DESCRIPTION
## Summary
- restyle the Play Lab game listing into horizontal feature cards with dedicated icon, summary, and CTA layout
- add experience-page styling for the new Play Lab card grid including icon treatments, responsive wrapping, and badge alignment

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c9bc2a15bc832d897c192c5fc45edb