### PR TITLE
Add scroll-triggered reveals and roadmap guardrails

### DIFF
--- a/src/components/CareerRoadmap.jsx
+++ b/src/components/CareerRoadmap.jsx
@@ -1,5 +1,5 @@
 // src/components/CareerRoadmap.jsx
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import {
   Route as RouteIcon,
@@ -10,12 +10,20 @@ import {
   AlertCircle,
   XCircle,
   BookOpen,
+  Briefcase,
+  TrendingUp,
+  Sparkles,
+  Compass,
 } from 'lucide-react';
 import useJobDataset from '../hooks/useJobDataset';
+import useRevealOnScroll from '../hooks/useRevealOnScroll';
 import {
   alignVectors,
   classifyType,
   getTrainingRecommendations,
+  computeTransitionSimilarity,
+  summarizeTransition,
+  getSimilarityBadge,
 } from '../utils/jobDataUtils';
 import '../styles/main.css';
 import SiteHeader from './SiteHeader';
@@ -73,15 +81,16 @@ const RoadmapDetails = ({ currentJob, targetJob }) => {
     return out;
   }, [groups, typeByName]);
 
-  const Group = ({ title, icon, color, items }) => {
+  const Group = ({ title, icon, tone, items }) => {
     if (!items.length) return null;
     return (
-      <div className={`panel panel-${color}`}>
-        <h3 className="panel-title">
-          {icon}
-          {title} ({items.length})
-        </h3>
-        <div className="grid-two">
+      <div className={`roadmap-group tone-${tone}`}>
+        <div className="roadmap-group__header">
+          <div className="roadmap-group__icon">{icon}</div>
+          <div className="roadmap-group__title">{title}</div>
+          <span className="roadmap-group__count">{items.length}</span>
+        </div>
+        <div className="roadmap-group__grid">
           {items.map((s, i) => {
             const recs = getTrainingRecommendations(
               s.name,
@@ -89,39 +98,32 @@ const RoadmapDetails = ({ currentJob, targetJob }) => {
               Math.abs(s.gap)
             );
             return (
-              <div key={i} className={`card border-${color}`}>
-                <div className="row space-between align-center mb-8">
-                  <h4 className="text-600">{s.name}</h4>
-                  <div className="row gap-8 text-sm">
-                    <span className={`text-${color}`}>Current: {s.current}/5</span>
-                    <span className="muted" aria-hidden="true">
-                      to
-                    </span>
-                    <span className="text-blue">Target: {s.target}/5</span>
-                  </div>
+              <div key={i} className="roadmap-card">
+                <div className="roadmap-card__header">
+                  <h4>{s.name}</h4>
+                  <span className="roadmap-card__range">
+                    {s.current}/5 → {s.target}/5
+                  </span>
                 </div>
-                <div className="mb-8">
-                  <div className={`text-xs text-${color} mb-4`}>
+                <div className="roadmap-card__body">
+                  <div className="roadmap-card__gap">
                     Gap: {s.gap > 0 ? '+' : ''}
                     {s.gap} levels
                   </div>
                   <div className="bar">
-                    <div
-                      className={`bar-fill ${color}`}
-                      style={{ width: (s.current / 5) * 100 + '%' }}
-                    >
+                    <div className="bar-fill blue" style={{ width: (s.current / 5) * 100 + '%' }}>
                       <div
-                        className={`bar-planned ${color}`}
+                        className="bar-planned green"
                         style={{ width: Math.max(0, ((s.target - s.current) / 5) * 100) + '%' }}
                       />
                     </div>
                   </div>
                 </div>
-                <div>
-                  <div className="text-sm muted mb-8">Recommended training:</div>
+                <div className="roadmap-card__footer">
+                  <span className="roadmap-card__label">Recommended training</span>
                   {recs.map((t, idx) => (
-                    <div key={idx} className="row text-xs muted">
-                      <BookOpen className={`icon-xs mr-6 text-${color}`} />
+                    <div key={idx} className="roadmap-card__training">
+                      <BookOpen className="icon-xs" />
                       {t}
                     </div>
                   ))}
@@ -137,100 +139,87 @@ const RoadmapDetails = ({ currentJob, targetJob }) => {
   if (!currentJob || !targetJob) return null;
 
   return (
-    <div className="card" style={{ padding: 16 }}>
-      <div className="row align-center gap-12 mb-16">
-        <RouteIcon className="icon-sm" />
-        <h2 className="title-md">Career Transition Roadmap</h2>
-      </div>
-
-      <div className="panel">
-        <div className="row space-between">
-          <div>
-            <div className="text-sm muted">Current</div>
-            <div className="text-600">{currentJob.title}</div>
-          </div>
-          <div>
-            <div className="text-sm muted">Target</div>
-            <div className="text-600">{targetJob.title}</div>
-          </div>
+    <div className="roadmap-insights" data-animate="fade-up">
+      <div className="roadmap-insights__header">
+        <div className="roadmap-insights__icon">
+          <RouteIcon className="icon-sm" />
+        </div>
+        <div>
+          <h2>Career transition roadmap</h2>
+          <p>Key skill shifts to move from your current role to the target.</p>
         </div>
       </div>
 
-      <div className="panel">
-        <h3 className="panel-title">Functional Skills</h3>
-        <Group
-          title="Already Strong"
-          icon={<CheckCircle className="icon-sm mr-8" />}
-          color="green"
-          items={groupsByType.functional.similar}
-        />
-        <Group
-          title="Needs Some Development"
-          icon={<AlertCircle className="icon-sm mr-8" />}
-          color="yellow"
-          items={groupsByType.functional.fair}
-        />
-        <Group
-          title="Needs Significant Development"
-          icon={<XCircle className="icon-sm mr-8" />}
-          color="red"
-          items={groupsByType.functional.needWork}
-        />
+      <div className="roadmap-insights__meta">
+        <div>
+          <span className="roadmap-insights__label">Current role</span>
+          <span className="roadmap-insights__value">{currentJob.title}</span>
+        </div>
+        <div className="roadmap-insights__divider" aria-hidden="true" />
+        <div>
+          <span className="roadmap-insights__label">Target role</span>
+          <span className="roadmap-insights__value">{targetJob.title}</span>
+        </div>
       </div>
 
-      <div className="panel">
-        <h3 className="panel-title">Soft Skills</h3>
-        <Group
-          title="Already Strong"
-          icon={<CheckCircle className="icon-sm mr-8" />}
-          color="green"
-          items={groupsByType.soft.similar}
-        />
-        <Group
-          title="Needs Some Development"
-          icon={<AlertCircle className="icon-sm mr-8" />}
-          color="yellow"
-          items={groupsByType.soft.fair}
-        />
-        <Group
-          title="Needs Significant Development"
-          icon={<XCircle className="icon-sm mr-8" />}
-          color="red"
-          items={groupsByType.soft.needWork}
-        />
-      </div>
+      <Group
+        title="Functional strengths"
+        icon={<CheckCircle className="icon-sm" />}
+        tone="green"
+        items={groupsByType.functional.similar}
+      />
+      <Group
+        title="Functional focus areas"
+        icon={<AlertCircle className="icon-sm" />}
+        tone="yellow"
+        items={groupsByType.functional.fair}
+      />
+      <Group
+        title="Critical functional gaps"
+        icon={<XCircle className="icon-sm" />}
+        tone="red"
+        items={groupsByType.functional.needWork}
+      />
+
+      <Group
+        title="Soft skill strengths"
+        icon={<CheckCircle className="icon-sm" />}
+        tone="green"
+        items={groupsByType.soft.similar}
+      />
+      <Group
+        title="Soft skill focus areas"
+        icon={<AlertCircle className="icon-sm" />}
+        tone="yellow"
+        items={groupsByType.soft.fair}
+      />
+      <Group
+        title="Critical soft skill gaps"
+        icon={<XCircle className="icon-sm" />}
+        tone="red"
+        items={groupsByType.soft.needWork}
+      />
 
       {(groupsByType.unknown.similar.length ||
         groupsByType.unknown.fair.length ||
         groupsByType.unknown.needWork.length) > 0 && (
-        <div className="panel">
-          <h3 className="panel-title">Other Skills</h3>
-          <Group
-            title="Already Strong"
-            icon={<CheckCircle className="icon-sm mr-8" />}
-            color="green"
-            items={groupsByType.unknown.similar}
-          />
-          <Group
-            title="Needs Some Development"
-            icon={<AlertCircle className="icon-sm mr-8" />}
-            color="yellow"
-            items={groupsByType.unknown.fair}
-          />
-          <Group
-            title="Needs Significant Development"
-            icon={<XCircle className="icon-sm mr-8" />}
-            color="red"
-            items={groupsByType.unknown.needWork}
-          />
-        </div>
+        <Group
+          title="Additional skills"
+          icon={<Sparkles className="icon-sm" />}
+          tone="lilac"
+          items={[
+            ...groupsByType.unknown.similar,
+            ...groupsByType.unknown.fair,
+            ...groupsByType.unknown.needWork,
+          ]}
+        />
       )}
     </div>
   );
 };
 
 export default function CareerRoadmap() {
-  const { jobs, divisions, ready } = useJobDataset();
+  const { jobs, divisions, skillIDF, ready } = useJobDataset();
   const location = useLocation();
   const { currentTitle: stateCurrentTitle = '', targetTitle: stateTargetTitle = '' } =
     location.state || {};
@@ -238,10 +227,21 @@ export default function CareerRoadmap() {
   const [plannerDivision, setPlannerDivision] = useState('all');
   const [plannerCurrentTitle, setPlannerCurrentTitle] = useState('');
   const [plannerTargetTitle, setPlannerTargetTitle] = useState('');
-  const [myPositionTitle] = useState(() => {
+  const [myPositionTitle, setMyPositionTitle] = useState(() => {
     if (typeof window === 'undefined') return '';
     return window.localStorage.getItem('eva-my-position') || '';
   });
+  const [myPickerDivision, setMyPickerDivision] = useState('all');
+  const [myPickerTitle, setMyPickerTitle] = useState('');
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    if (myPositionTitle) {
+      window.localStorage.setItem('eva-my-position', myPositionTitle);
+    } else {
+      window.localStorage.removeItem('eva-my-position');
+    }
+  }, [myPositionTitle]);
 
   useEffect(() => {
     if (stateCurrentTitle) {
@@ -251,21 +251,33 @@ export default function CareerRoadmap() {
     }
   }, [stateCurrentTitle, myPositionTitle, plannerCurrentTitle]);
 
+  const myPosition = useMemo(
+    () => jobs.find((j) => j.title === myPositionTitle) || null,
+    [jobs, myPositionTitle]
+  );
+
   useEffect(() => {
     if (stateTargetTitle) {
       setPlannerTargetTitle(stateTargetTitle);
     }
   }, [stateTargetTitle]);
 
-  const myPosition = useMemo(
-    () => jobs.find((j) => j.title === myPositionTitle) || null,
-    [jobs, myPositionTitle]
-  );
+  useEffect(() => {
+    if (myPosition && !myPickerTitle) {
+      setMyPickerDivision(myPosition.division || 'all');
+      setMyPickerTitle(myPosition.title);
+    }
+  }, [myPosition, myPickerTitle]);
 
   const plannerJobsFiltered = useMemo(() => {
     if (plannerDivision === 'all') return jobs;
     return jobs.filter((j) => j.division === plannerDivision);
   }, [jobs, plannerDivision]);
+
+  const myPickerJobs = useMemo(() => {
+    if (myPickerDivision === 'all') return jobs;
+    return jobs.filter((j) => j.division === myPickerDivision);
+  }, [jobs, myPickerDivision]);
 
   const plannerCurrentJob = useMemo(
     () => jobs.find((j) => j.title === plannerCurrentTitle) || null,
@@ -277,144 +289,377 @@ export default function CareerRoadmap() {
     [jobs, plannerTargetTitle]
   );
 
+  const simScore = useCallback(
+    (currentJob, targetJob) =>
+      computeTransitionSimilarity(currentJob, targetJob, skillIDF),
+    [skillIDF]
+  );
+
+  const recommendationsForMyPosition = useMemo(() => {
+    if (!myPosition) return [];
+    return jobs
+      .filter((job) => job.id !== myPosition.id)
+      .map((job) => ({
+        ...job,
+        similarity: simScore(myPosition, job),
+        summary: summarizeTransition(myPosition, job, 2),
+      }))
+      .filter((job) => job.similarity >= 60)
+      .sort((a, b) => b.similarity - a.similarity)
+      .slice(0, 8);
+  }, [jobs, myPosition, simScore]);
+
+  const ensurePlannerCanShowJob = useCallback(
+    (jobTitle) => {
+      if (!jobTitle) return;
+      const job = jobs.find((j) => j.title === jobTitle);
+      if (!job) return;
+      if (plannerDivision !== 'all' && job.division !== plannerDivision) {
+        setPlannerDivision('all');
+      }
+    },
+    [jobs, plannerDivision]
+  );
+
+  const setMyPositionFromPicker = useCallback(() => {
+    if (!myPickerTitle) return;
+    ensurePlannerCanShowJob(myPickerTitle);
+    setMyPositionTitle(myPickerTitle);
+    if (!plannerCurrentTitle) {
+      setPlannerCurrentTitle(myPickerTitle);
+    }
+  }, [myPickerTitle, setMyPositionTitle, plannerCurrentTitle, ensurePlannerCanShowJob]);
+
   const hasSelection = plannerCurrentJob && plannerTargetJob;
+
+  const scrollToPlanner = () => {
+    const el = document.getElementById('roadmap-planner');
+    if (el) {
+      el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    }
+  };
+
+  const getToneForScore = (score) => {
+    if (score >= 90) return 'tone-green';
+    if (score >= 80) return 'tone-yellow';
+    if (score >= 70) return 'tone-lilac';
+    if (score >= 60) return 'tone-blue';
+    return 'tone-neutral';
+  };
+
+  useRevealOnScroll(
+    plannerCurrentTitle,
+    plannerTargetTitle,
+    myPositionTitle,
+    recommendationsForMyPosition.length,
+    jobs.length
+  );
 
   return (
     <div className="page solid-bg experience-page">
       <SiteHeader />
 
       <div className="container content experience-content">
-        <div className="page-heading">
-          <div className="page-heading-main">
-            <div className="page-heading-icon" aria-hidden="true">
-              <RouteIcon className="icon-md" />
+        <section className="experience-hero experience-hero--explorer" data-animate="fade-slide">
+          <div className="experience-hero__header">
+            <div className="experience-hero__icon" aria-hidden="true">
+              <Compass className="icon-lg" />
             </div>
             <div>
-              <h1 className="page-heading-title">Explorer Roadmap</h1>
-              <p className="page-heading-subtitle">Plan your next move across the SPH Career Framework</p>
+              <h1 className="experience-hero__title">Explorer Roadmap</h1>
+              <p className="experience-hero__subtitle">
+                Plot how you move across the SPH Career Framework with personalised skill insights.
+              </p>
             </div>
           </div>
-        </div>
-
-        <div className="card section">
-          <div className="row space-between align-start wrap" style={{ gap: 16 }}>
-            <div className="column gap-8" style={{ flex: 1, minWidth: 260 }}>
-              <h2 className="section-h2" style={{ marginTop: 0 }}>
-                Plot your next move
-              </h2>
-              <p className="muted text-sm">
-                Choose the role you are in today and the role you aspire to. The roadmap highlights the
-                functional and soft skill shifts required to make the transition.
-              </p>
-              {myPosition && (
-                <div className="hero-status-card" style={{ marginTop: 12 }}>
-                  <div className="status-icon" aria-hidden="true">
-                    <MapPin className="icon-sm" />
-                  </div>
-                  <div>
-                    <div className="status-label">Saved starting role</div>
-                    <div className="status-value">{myPosition.title}</div>
-                  </div>
-                  <Link to="/career-explorer" className="btn ghost small">
-                    Update
-                  </Link>
-                </div>
+          <div className="experience-hero__grid">
+            <div className="experience-hero__status-card">
+              {myPosition ? (
+                <>
+                  <span className="experience-hero__status-label">Saved starting role</span>
+                  <span className="experience-hero__status-value">{myPosition.title}</span>
+                  <button className="chip chip--ghost" type="button" onClick={scrollToPlanner}>
+                    Update or plan from here
+                  </button>
+                </>
+              ) : (
+                <>
+                  <span className="experience-hero__status-label">Ready to personalise?</span>
+                  <p className="experience-hero__status-text">
+                    Save your current role below to unlock curated transitions and faster planning.
+                  </p>
+                  <button className="chip-link" type="button" onClick={scrollToPlanner}>
+                    Save my position
+                  </button>
+                </>
               )}
             </div>
-            <div className="column gap-8" style={{ minWidth: 260, maxWidth: 320 }}>
-              <div className="panel" style={{ margin: 0 }}>
-                <div className="panel-title row align-center">
-                  <Users className="icon-sm mr-8" /> Quick tips
+            <div className="experience-hero__actions">
+              <button type="button" className="button button--inverse" onClick={scrollToPlanner}>
+                Start planning
+              </button>
+              <Link to="/career-explorer" className="button button--ghost">
+                Launch career explorer
+              </Link>
+            </div>
+          </div>
+        </section>
+
+        <section id="roadmap-planner" className="roadmap-panel" data-animate="fade-up">
+          <div className="roadmap-panel__grid">
+            <div className="roadmap-card-block">
+              <div className="roadmap-card-block__header">
+                <Sparkles className="icon-sm" />
+                <div>
+                  <h2>My position</h2>
+                  <p>Lock in your current role to benchmark every opportunity.</p>
                 </div>
-                <ul className="list text-sm muted" style={{ paddingLeft: 16, margin: 0 }}>
-                  <li>Use the function filter to narrow options.</li>
-                  <li>Swap targets anytime to compare different missions.</li>
-                  <li>
-                    Save your current role from the Explore Careers page for faster prefill in the planner.
-                  </li>
-                </ul>
               </div>
-            </div>
-          </div>
-        </div>
-
-        <div className="card section">
-          <div className="toolbar-grid" style={{ marginBottom: 16 }}>
-            <div className="field">
-              <label className="text-sm muted">Filter by Function</label>
-              <div className="relative">
-                <Filter className="icon-sm muted abs-left" />
-                <select
-                  className="input pl"
-                  value={plannerDivision}
-                  onChange={(e) => {
-                    setPlannerDivision(e.target.value);
-                    setPlannerCurrentTitle('');
-                    setPlannerTargetTitle('');
-                  }}
+              <div className="roadmap-card-block__body">
+                <div className="field field--elevated">
+                  <label className="field__label" htmlFor="my-position-division">
+                    Function
+                  </label>
+                  <div className="field__control">
+                    <Filter className="icon-sm field__icon" />
+                    <select
+                      id="my-position-division"
+                      className="input input--elevated"
+                      value={myPickerDivision}
+                      onChange={(e) => {
+                        setMyPickerDivision(e.target.value);
+                        setMyPickerTitle('');
+                      }}
+                    >
+                      <option value="all">All functions</option>
+                      {divisions.map((d) => (
+                        <option key={d} value={d}>
+                          {d}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+                </div>
+                <div className="field field--elevated">
+                  <label className="field__label" htmlFor="my-position-title">
+                    Position
+                  </label>
+                  <div className="field__control">
+                    <Briefcase className="icon-sm field__icon" />
+                    <select
+                      id="my-position-title"
+                      className="input input--elevated"
+                      value={myPickerTitle}
+                      onChange={(e) => setMyPickerTitle(e.target.value)}
+                    >
+                      <option value="">Select your position...</option>
+                      {myPickerJobs.map((job) => (
+                        <option key={job.id} value={job.title}>
+                          {job.title} - {job.division}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+                </div>
+              </div>
+              <div className="roadmap-card-block__actions">
+                <button
+                  type="button"
+                  className="button button--primary"
+                  onClick={setMyPositionFromPicker}
+                  disabled={!myPickerTitle}
                 >
-                  <option value="all">All Functions</option>
-                  {divisions.map((d) => (
-                    <option key={d} value={d}>
-                      {d}
-                    </option>
-                  ))}
-                </select>
+                  Save my position
+                </button>
+                {myPosition && (
+                  <button
+                    type="button"
+                    className="chip chip--ghost"
+                    onClick={() => {
+                      ensurePlannerCanShowJob(myPosition.title);
+                      setPlannerCurrentTitle(myPosition.title);
+                    }}
+                  >
+                    Prefill planner with saved role
+                  </button>
+                )}
               </div>
             </div>
-            <div className="field" />
-          </div>
 
-          <div className="grid-two">
-            <div className="column gap-8">
-              <label className="text-sm muted">Current Role</label>
-              <select
-                className="input"
-                value={plannerCurrentTitle}
-                onChange={(e) => setPlannerCurrentTitle(e.target.value)}
-              >
-                <option value="">
-                  {myPosition ? `My Position: ${myPosition.title}` : 'Select current role...'}
-                </option>
-                {plannerJobsFiltered.map((j) => (
-                  <option key={j.id} value={j.title}>
-                    {j.title} - {j.division}
-                  </option>
-                ))}
-              </select>
+            <div className="roadmap-card-block">
+              <div className="roadmap-card-block__header">
+                <RouteIcon className="icon-sm" />
+                <div>
+                  <h2>Roadmap planner</h2>
+                  <p>Select your current and target roles to reveal the skill roadmap.</p>
+                </div>
+              </div>
+              <div className="roadmap-card-block__body roadmap-card-block__body--grid">
+                <div className="field field--elevated">
+                  <label className="field__label" htmlFor="planner-division">
+                    Function filter
+                  </label>
+                  <div className="field__control">
+                    <Filter className="icon-sm field__icon" />
+                    <select
+                      id="planner-division"
+                      className="input input--elevated"
+                      value={plannerDivision}
+                      onChange={(e) => {
+                        setPlannerDivision(e.target.value);
+                        setPlannerCurrentTitle('');
+                        setPlannerTargetTitle('');
+                      }}
+                    >
+                      <option value="all">All functions</option>
+                      {divisions.map((d) => (
+                        <option key={d} value={d}>
+                          {d}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+                </div>
+
+                <div className="field field--elevated">
+                  <label className="field__label" htmlFor="planner-current">
+                    Current role
+                  </label>
+                  <div className="field__control">
+                    <MapPin className="icon-sm field__icon" />
+                    <select
+                      id="planner-current"
+                      className="input input--elevated"
+                      value={plannerCurrentTitle}
+                      onChange={(e) => setPlannerCurrentTitle(e.target.value)}
+                    >
+                      <option value="">
+                        {myPosition ? `My position: ${myPosition.title}` : 'Select current role...'}
+                      </option>
+                      {plannerJobsFiltered.map((job) => (
+                        <option key={job.id} value={job.title}>
+                          {job.title} - {job.division}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+                </div>
+
+                <div className="field field--elevated">
+                  <label className="field__label" htmlFor="planner-target">
+                    Target role
+                  </label>
+                  <div className="field__control">
+                    <TrendingUp className="icon-sm field__icon" />
+                    <select
+                      id="planner-target"
+                      className="input input--elevated"
+                      value={plannerTargetTitle}
+                      onChange={(e) => setPlannerTargetTitle(e.target.value)}
+                    >
+                      <option value="">Select target role...</option>
+                      {plannerJobsFiltered.map((job) => (
+                        <option key={job.id} value={job.title}>
+                          {job.title} - {job.division}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+                </div>
+              </div>
+              <div className="roadmap-card-block__tips">
+                <Users className="icon-sm" />
+                <p>Tip: experiment with multiple targets to compare effort and skill emphasis.</p>
+              </div>
             </div>
-
-            <div className="column gap-8">
-              <label className="text-sm muted">Target Role</label>
-              <select
-                className="input"
-                value={plannerTargetTitle}
-                onChange={(e) => setPlannerTargetTitle(e.target.value)}
-              >
-                <option value="">Select target role...</option>
-                {plannerJobsFiltered.map((j) => (
-                  <option key={j.id} value={j.title}>
-                    {j.title} - {j.division}
-                  </option>
-                ))}
-              </select>
-            </div>
           </div>
-        </div>
+        </section>
 
-        {hasSelection ? (
-          <RoadmapDetails currentJob={plannerCurrentJob} targetJob={plannerTargetJob} />
-        ) : (
-          <div className="empty" style={{ padding: 16 }}>
-            {ready ? (
-              <p className="muted">
-                Pick both a current and a target role to see the roadmap insights.
+        <section className="roadmap-results" data-animate="fade-stagger">
+          {hasSelection ? (
+            <RoadmapDetails currentJob={plannerCurrentJob} targetJob={plannerTargetJob} />
+          ) : (
+            <div className="explorer-empty">
+              {ready ? (
+                <p>Pick both a current and a target role to reveal the roadmap insights.</p>
+              ) : (
+                <p>Loading roles from the career framework...</p>
+              )}
+            </div>
+          )}
+        </section>
+
+        <section className="roadmap-recommendations" data-animate="fade-up">
+          <div className="roadmap-recommendations__header">
+            <div>
+              <h2 className="section-h2">Personalised recommendations</h2>
+              <p className="muted text-sm">
+                Discover adjacent roles that build on your strengths and stretch your capabilities.
               </p>
-            ) : (
-              <p className="muted">Loading roles from the career framework...</p>
-            )}
+            </div>
           </div>
-        )}
+
+          {myPosition ? (
+            recommendationsForMyPosition.length > 0 ? (
+              <div className="roadmap-recommendations__grid">
+                {recommendationsForMyPosition.map((job) => {
+                  const badge = getSimilarityBadge(job.similarity);
+                  const toneClass = getToneForScore(job.similarity);
+                  const strengths = job.summary.strengths.map((s) => s.name).join(', ');
+                  const gaps = job.summary.gaps.map((g) => `${g.name} (+${g.gap})`).join(', ');
+                  return (
+                    <div key={job.id} className={`roadmap-recommendation ${toneClass}`}>
+                      <div className="roadmap-recommendation__header">
+                        <div>
+                          <h3>{job.title}</h3>
+                          <span className="muted text-xs">{job.division}</span>
+                        </div>
+                        <span className={badge.color}>{badge.label}</span>
+                      </div>
+                      {(strengths || gaps) && (
+                        <div className="roadmap-recommendation__summary">
+                          {strengths && (
+                            <div>
+                              <strong>Strengths:</strong> {strengths}
+                            </div>
+                          )}
+                          {gaps && (
+                            <div>
+                              <strong>Gaps:</strong> {gaps}
+                            </div>
+                          )}
+                        </div>
+                      )}
+                      <div className="roadmap-recommendation__actions">
+                        <button
+                          type="button"
+                          className="button button--ghost"
+                          onClick={() => {
+                            ensurePlannerCanShowJob(myPosition.title);
+                            ensurePlannerCanShowJob(job.title);
+                            setPlannerCurrentTitle(myPosition.title);
+                            setPlannerTargetTitle(job.title);
+                            scrollToPlanner();
+                          }}
+                        >
+                          Plan this move
+                        </button>
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            ) : (
+              <div className="explorer-empty explorer-empty--inline">
+                <p>We're analysing your saved role for recommendations. Try a different function filter.</p>
+              </div>
+            )
+          ) : (
+            <div className="explorer-empty explorer-empty--inline">
+              <p>Save your current position above to see tailored transitions.</p>
+            </div>
+          )}
+        </section>
       </div>
     </div>
   );

--- a/src/components/HeroSection.jsx
+++ b/src/components/HeroSection.jsx
@@ -34,7 +34,7 @@ export default function HeroSection({ onExplore = () => {}, primaryCta, secondar
   return (
     <section className="hero" aria-labelledby="hero-title">
       <div className="container hero__inner">
-        <div className="hero__content">
+        <div className="hero__content" data-animate="fade-slide">
           <span className="hero__eyebrow">Shape your next move</span>
           <h1 id="hero-title" className="hero__title">
             SPH Career Framework
@@ -49,7 +49,7 @@ export default function HeroSection({ onExplore = () => {}, primaryCta, secondar
             {renderAction(secondaryAction, 'ghost')}
           </div>
         </div>
-        <div className="hero__media" aria-hidden="true">
+        <div className="hero__media" aria-hidden="true" data-animate="fade-up">
           <div className="hero__animation">
             <div className="hero__orbit" />
             <div className="hero__spark" />

--- a/src/components/HomePage.jsx
+++ b/src/components/HomePage.jsx
@@ -4,9 +4,11 @@ import SiteHeader from './SiteHeader';
 import HeroSection from './HeroSection';
 import FrameworkFunctions from './FrameworkFunctions';
 import { frameworkFunctions } from '../data/frameworkFunctions';
+import useRevealOnScroll from '../hooks/useRevealOnScroll';
 
 export default function HomePage() {
   const functionsRef = useRef(null);
+  useRevealOnScroll();
 
   const handleExplore = () => {
     if (functionsRef.current) {

--- a/src/components/JobSkillsMatcher.jsx
+++ b/src/components/JobSkillsMatcher.jsx
@@ -13,21 +13,21 @@ import {
 } from 'lucide-react';
 import '../styles/main.css';
 import useJobDataset from '../hooks/useJobDataset';
-import { alignVectors, classifyType } from '../utils/jobDataUtils';
+import {
+  classifyType,
+  computeTransitionSimilarity,
+  summarizeTransition,
+  getSimilarityBadge,
+} from '../utils/jobDataUtils';
 import SiteHeader from './SiteHeader';
+import useRevealOnScroll from '../hooks/useRevealOnScroll';
 
-function getSimilarityColor(sim) {
-  if (sim >= 70) return 'match match-excellent';
-  if (sim >= 60) return 'match match-good';
-  if (sim >= 50) return 'match match-fair';
-  return 'match match-low';
-}
-
-function getSimilarityBadge(sim) {
-  if (sim >= 90) return { label: 'Excellent', color: 'badge solid green' };
-  if (sim >= 80) return { label: 'Good', color: 'badge solid yellow' };
-  if (sim >= 70) return { label: 'Fair', color: 'badge solid orange' };
-  return { label: 'Low', color: 'badge solid gray' };
+function getSimilarityTone(sim) {
+  if (sim >= 90) return 'tone-green';
+  if (sim >= 80) return 'tone-yellow';
+  if (sim >= 70) return 'tone-lilac';
+  if (sim >= 60) return 'tone-blue';
+  return 'tone-neutral';
 }
 
 /* ------------------------- Main Component (Single Page) ------------------------- */
@@ -42,9 +42,6 @@ const JobSkillsMatcher = () => {
     if (typeof window === 'undefined') return '';
     return window.localStorage.getItem('eva-my-position') || '';
   });
-
-  const [myPickerDivision, setMyPickerDivision] = useState('all');
-  const [myPickerTitle, setMyPickerTitle] = useState('');
 
   useEffect(() => {
     if (typeof window === 'undefined') return;
@@ -61,13 +58,6 @@ const JobSkillsMatcher = () => {
   );
 
   const roadmapLinkState = myPosition?.title ? { currentTitle: myPosition.title } : undefined;
-  const selectedJobRoadmapState = selectedJob
-    ? {
-        ...(myPosition?.title ? { currentTitle: myPosition.title } : {}),
-        targetTitle: selectedJob.title,
-      }
-    : undefined;
-
   /* ---------- Top list filtering ---------- */
   const filteredJobs = useMemo(() => {
     const q = searchTerm.toLowerCase();
@@ -94,93 +84,24 @@ const JobSkillsMatcher = () => {
 
   // Weighted, directional similarity: current (source) -> target
   const simScore = React.useCallback(
-    (currentJob, targetJob) => {
-      if (!currentJob || !targetJob || currentJob.id === targetJob.id) return 100;
-      const [va, vb, names] = alignVectors(currentJob, targetJob);
-      if (!names.length) return 0;
-
-      // Per-skill weights using target's importance, type, and global IDF
-      const weights = names.map((n) => {
-        const importance = targetJob.skillMap?.[n] ?? 0; // target requirement (0..5)
-        const typeRaw = (targetJob.skillTypeByName?.[n] || currentJob.skillTypeByName?.[n] || '').toLowerCase();
-        const typeWeight = /functional/.test(typeRaw) ? 1.15 : /soft/.test(typeRaw) ? 0.95 : 1.0;
-        const base = 0.5 + (Math.max(0, Math.min(5, importance)) / 5) * 0.5; // 0.5 .. 1.0
-        const idf = skillIDF[n] ?? 1.0; // ~0.85 .. 1.35 typically
-        return base * typeWeight * idf;
-      });
-
-      // Weighted cosine similarity
-      let num = 0, denA = 0, denB = 0, wsum = 0;
-      for (let i = 0; i < names.length; i++) {
-        const w = weights[i] || 1;
-        const a = va[i] || 0;
-        const b = vb[i] || 0;
-        num += w * a * b;
-        denA += w * a * a;
-        denB += w * b * b;
-        wsum += w;
-      }
-      if (denA <= 0 || denB <= 0) return 0;
-      let cosine = num / (Math.sqrt(denA) * Math.sqrt(denB)); // 0..1
-
-      // Penalize large positive gaps on high-importance skills in target
-      let gapAccum = 0;
-      for (let i = 0; i < names.length; i++) {
-        const w = weights[i] || 1;
-        const a = va[i] || 0;
-        const b = vb[i] || 0;
-        if (b > a) {
-          const g = (b - a) / 5; // 0..1
-          gapAccum += w * g * g; // quadratic penalty
-        }
-      }
-      const gapNorm = wsum > 0 ? Math.min(0.35, gapAccum / (wsum || 1)) : 0; // cap penalty influence
-      const score01 = Math.max(0, Math.min(1, cosine - 0.5 * gapNorm));
-      return Math.round(score01 * 100);
-    },
+    (currentJob, targetJob) =>
+      computeTransitionSimilarity(currentJob, targetJob, skillIDF),
     [skillIDF]
   );
-
-  // Brief explanation: top strengths and gaps for a transition
-  const explainMatch = React.useCallback((currentJob, targetJob, max = 3) => {
-    const [va, vb, names] = alignVectors(currentJob, targetJob);
-    const diffs = names.map((n, i) => ({
-      name: n,
-      current: va[i] || 0,
-      target: vb[i] || 0,
-      gap: (vb[i] || 0) - (va[i] || 0),
-      type: classifyType((targetJob?.skillTypeByName?.[n] ?? currentJob?.skillTypeByName?.[n]) || ''),
-    }));
-    const strengths = diffs
-      .filter((d) => d.gap <= 0 && d.target > 0)
-      .sort((a, b) => b.target - a.target)
-      .slice(0, max);
-    const gaps = diffs
-      .filter((d) => d.gap > 0)
-      .sort((a, b) => b.gap - a.gap)
-      .slice(0, max);
-    return { strengths, gaps };
-  }, []);
 
   // Matching against the currently selected job (right panel list)
   const matchingJobsForSelected = useMemo(() => {
     if (!selectedJob) return [];
     return jobs
       .filter((job) => job.id !== selectedJob.id)
-      .map((job) => ({ ...job, similarity: simScore(selectedJob, job) }))
-      .filter((job) => job.similarity >= 70)
+      .map((job) => ({
+        ...job,
+        similarity: simScore(selectedJob, job),
+        summary: summarizeTransition(selectedJob, job, 2),
+      }))
+      .filter((job) => job.similarity >= 65)
       .sort((a, b) => b.similarity - a.similarity);
   }, [selectedJob, jobs, simScore]);
-
-  // Global recommendations for "My Position"
-  const recommendationsForMyPosition = useMemo(() => {
-    if (!myPosition) return [];
-    return jobs
-      .filter((job) => job.id !== myPosition.id)
-      .map((job) => ({ ...job, similarity: simScore(myPosition, job) }))
-      .sort((a, b) => b.similarity - a.similarity)
-      .slice(0, 8);
-  }, [myPosition, jobs, simScore]);
 
   // Split selected job's skills into functional vs soft for clearer display
   const selectedJobSkillsByType = useMemo(() => {
@@ -197,55 +118,115 @@ const JobSkillsMatcher = () => {
     return { functional, soft, unknown };
   }, [selectedJob]);
 
-  /* ---------- My Position Picker (separate section) ---------- */
-  const myPickerJobs = useMemo(() => {
-    if (myPickerDivision === 'all') return jobs;
-    return jobs.filter((j) => j.division === myPickerDivision);
-  }, [jobs, myPickerDivision]);
-
-  const setMyPositionFromPicker = () => {
-    if (!myPickerTitle) return;
-    setMyPositionTitle(myPickerTitle);
-  };
+  useRevealOnScroll(
+    selectedJob ? selectedJob.id : 0,
+    filteredJobs.length,
+    matchingJobsForSelected.length,
+    myPosition ? myPosition.id : 0
+  );
 
   return (
     <div className="page solid-bg experience-page">
       <SiteHeader />
 
-      {/* Content */}
       <div className="container content experience-content">
-        <div className="page-heading">
-          <div className="page-heading-main">
-            <div className="page-heading-icon" aria-hidden="true">
-              <Route className="icon-md" />
+        <section className="experience-hero experience-hero--explorer" data-animate="fade-slide">
+          <div className="experience-hero__header">
+            <div className="experience-hero__icon" aria-hidden="true">
+              <Route className="icon-lg" />
             </div>
             <div>
-              <h1 className="page-heading-title">SPH Career Explorer</h1>
-              <p className="page-heading-subtitle">
+              <h1 className="experience-hero__title">SPH Career Explorer</h1>
+              <p className="experience-hero__subtitle">
                 Explore SPH roles, compare skills, and shortlist next-step opportunities.
               </p>
             </div>
           </div>
-        </div>
+          <div className="experience-hero__grid">
+            <div className="experience-hero__status-card">
+              {myPosition ? (
+                <>
+                  <span className="experience-hero__status-label">Saved starting role</span>
+                  <span className="experience-hero__status-value">{myPosition.title}</span>
+                  <Link to="/roadmap" state={roadmapLinkState} className="chip-link">
+                    Manage in roadmap
+                  </Link>
+                </>
+              ) : (
+                <>
+                  <span className="experience-hero__status-label">Personalise your view</span>
+                  <p className="experience-hero__status-text">
+                    Save your current role in the roadmap planner to unlock tailored comparisons here.
+                  </p>
+                  <Link to="/roadmap" className="chip-link">
+                    Go to roadmap planner
+                  </Link>
+                </>
+              )}
+            </div>
+            <div className="experience-hero__actions">
+              <Link to="/roadmap" state={roadmapLinkState} className="button button--inverse">
+                <Route className="icon-xs mr-6" />
+                Open roadmap planner
+              </Link>
+              <button
+                type="button"
+                className="button button--ghost"
+                onClick={() =>
+                  document.getElementById('career-explorer-filters')?.scrollIntoView({
+                    behavior: 'smooth',
+                    block: 'start',
+                  })
+                }
+              >
+                Browse roles
+              </button>
+            </div>
+          </div>
+        </section>
 
-        
-
-        {/* ========== SECTION: My Position ========== */}
-        <section>
-          <h2 className="section-h2">My Position</h2>
-          <div className="card section">
-            <div className="toolbar-grid">
-              <div className="field">
-                <label className="text-sm muted">Function</label>
+        <section id="career-explorer-filters" className="explorer-panel" data-animate="fade-up">
+          <div className="explorer-panel__header">
+            <div>
+              <h2 className="section-h2">Browse positions</h2>
+              <p className="muted text-sm">
+                Use search and filters to surface roles across the SPH framework. Open a card to view its skill DNA.
+              </p>
+            </div>
+            {myPosition && <span className="chip chip--outline">Benchmarking vs {myPosition.title}</span>}
+          </div>
+          <div className="explorer-filter-grid">
+            <div className="field field--elevated">
+              <label className="field__label" htmlFor="explorer-search">
+                Search positions
+              </label>
+              <div className="field__control">
+                <Search className="icon-sm field__icon" />
+                <input
+                  id="explorer-search"
+                  type="text"
+                  placeholder="Search by title or division..."
+                  className="input input--elevated"
+                  value={searchTerm}
+                  onChange={(e) => setSearchTerm(e.target.value)}
+                  aria-label="Search jobs"
+                />
+              </div>
+            </div>
+            <div className="field field--elevated">
+              <label className="field__label" htmlFor="explorer-division">
+                Division filter
+              </label>
+              <div className="field__control">
+                <Filter className="icon-sm field__icon" />
                 <select
-                  className="input"
-                  value={myPickerDivision}
-                  onChange={(e) => {
-                    setMyPickerDivision(e.target.value);
-                    setMyPickerTitle('');
-                  }}
+                  id="explorer-division"
+                  className="input input--elevated"
+                  value={selectedDivision}
+                  onChange={(e) => setSelectedDivision(e.target.value)}
+                  aria-label="Filter by division"
                 >
-                  <option value="all">All Functions</option>
+                  <option value="all">All divisions</option>
                   {divisions.map((d) => (
                     <option key={d} value={d}>
                       {d}
@@ -253,234 +234,88 @@ const JobSkillsMatcher = () => {
                   ))}
                 </select>
               </div>
-              <div className="field">
-                <label className="text-sm muted">Position</label>
-                <select
-                  className="input"
-                  value={myPickerTitle}
-                  onChange={(e) => setMyPickerTitle(e.target.value)}
-                >
-                  <option value="">Select your position...</option>
-                  {myPickerJobs.map((j) => (
-                    <option key={j.id} value={j.title}>
-                      {j.title} - {j.division}
-                    </option>
-                  ))}
-                </select>
-              </div>
-            </div>
-
-            <div className="row gap-12" style={{ marginTop: 12 }}>
-              <button className="btn primary" onClick={setMyPositionFromPicker} disabled={!myPickerTitle}>
-                Set as My Position
-              </button>
-              {myPosition && (
-                <button
-                  className="btn"
-                  onClick={() =>
-                    navigate('/roadmap', {
-                      state: { currentTitle: myPosition.title },
-                    })
-                  }
-                >
-                  Plan from My Position
-                </button>
-              )}
             </div>
           </div>
         </section>
 
-        {/* Filters for browsing */}
-        <div className="toolbar card">
-          <div className="toolbar-grid">
-            <div className="field">
-              <Search className="icon-sm muted abs-left" />
-              <input
-                type="text"
-                placeholder="Search jobs by title or division..."
-                className="input pl"
-                value={searchTerm}
-                onChange={(e) => setSearchTerm(e.target.value)}
-                aria-label="Search jobs"
-              />
-            </div>
-            <div className="field">
-              <Filter className="icon-sm muted abs-left" />
-              <select
-                className="input pl"
-                value={selectedDivision}
-                onChange={(e) => setSelectedDivision(e.target.value)}
-                aria-label="Filter by division"
-              >
-                <option value="all">All Divisions</option>
-                {divisions.map((d) => (
-                  <option key={d} value={d}>
-                    {d}
-                  </option>
-                ))}
-              </select>
-            </div>
-          </div>
-        </div>
-
-        {/* ========== SECTION: Recommendations for My Position ========== */}
-        {myPosition && (
-          <>
-            <h2 className="section-h2">Recommendations</h2>
-            {recommendationsForMyPosition.length > 0 ? (
-              <div className="card section">
-                <div className="grid-cards">
-                  {recommendationsForMyPosition.map((job) => {
-                    const badge = getSimilarityBadge(job.similarity);
-                    const exp = explainMatch(myPosition, job);
-                    const sFunc = exp.strengths.filter((s) => s.type === 'functional').map((s) => s.name).join(', ');
-                    const sSoft = exp.strengths.filter((s) => s.type === 'soft').map((s) => s.name).join(', ');
-                    const gFunc = exp.gaps.filter((g) => g.type === 'functional').map((g) => `${g.name} (+${g.gap})`).join(', ');
-                    const gSoft = exp.gaps.filter((g) => g.type === 'soft').map((g) => `${g.name} (+${g.gap})`).join(', ');
-                    return (
-                      <div key={job.id} className={getSimilarityColor(job.similarity)}>
-                        <div className="row space-between mb-6">
-                          <h4 className="text-sm text-600">{job.title}</h4>
-                          <span className={badge.color}>{badge.label}</span>
-                        </div>
-                        <p className="text-xs muted mb-8">{job.division}</p>
-                        {(exp.strengths.length > 0 || exp.gaps.length > 0) && (
-                          <div className="text-xs muted mb-8">
-                            {sFunc && <div>Strengths (Functional): {sFunc}</div>}
-                            {sSoft && <div>Strengths (Soft): {sSoft}</div>}
-                            {gFunc && <div>Gaps (Functional): {gFunc}</div>}
-                            {gSoft && <div>Gaps (Soft): {gSoft}</div>}
-                          </div>
-                        )}
-                        <button
-                          className="btn primary full row center"
-                          onClick={() =>
-                            navigate('/roadmap', {
-                              state: { currentTitle: myPosition.title, targetTitle: job.title },
-                            })
-                          }
-                          title="Plan this move in the roadmap"
-                        >
-                          <Route className="icon-xs mr-6 white" />
-                          Plan in Roadmap
-                        </button>
-                      </div>
-                    );
-                  })}
-                </div>
-              </div>
-            ) : (
-              <div className="empty">No recommendations yet.</div>
-            )}
-          </>
-        )}
-
-        {/* ========== SECTION: Browse Positions ========== */}
-        <h2 className="section-h2" id="browse">Browse Positions</h2>
-        <div className="layout">
-          {/* Left: groups */}
-          <div className={selectedJob ? 'col main half' : 'col main full'}>
-            {Object.keys(groupedJobs).map((division) => (
-              <div key={division} className="card section">
-                <h3 className="title-md mb-16">{division}</h3>
-                <div className="grid-cards">
-                  {groupedJobs[division].map((job) => {
-                    const isSelected = selectedJob && selectedJob.id === job.id;
-
-                    // Compatibility vs My Position
-                    let compatBadge = null;
-                    let borderStyle = {};
-                    if (myPosition) {
-                      const sim = simScore(myPosition, job);
-                      const badge = getSimilarityBadge(sim);
-                      compatBadge = <span className={badge.color}>{badge.label}</span>;
-                      if (sim >= 90) borderStyle = { borderColor: 'var(--green)' };
-                      else if (sim >= 80) borderStyle = { borderColor: 'var(--yellow)' };
-                      else if (sim >= 70) borderStyle = { borderColor: 'var(--orange)' };
-                      else borderStyle = { borderColor: '#d1d5db' };
-                    }
-
-                    return (
-                      <button
-                        key={job.id}
-                        className={'job-pill ' + (isSelected ? 'selected' : '')}
-                        style={borderStyle}
-                        onClick={() => setSelectedJob(job)}
-                        aria-pressed={isSelected}
-                        title={`Open ${job.title}`}
-                      >
-                        <div className="text-600 row space-between align-center">
-                          <span>{job.title}</span>
-                          {myPosition && compatBadge}
-                        </div>
-                        <div className="muted text-xs mt-4">
-                          {(job.division || '').split(' ')[0]}
-                        </div>
-                      </button>
-                    );
-                  })}
-                </div>
-              </div>
-            ))}
-
-            {Object.keys(groupedJobs).length === 0 && (
-              <div className="empty">
-                <Users className="icon-xl muted mb-12" />
-                <h3>No jobs found</h3>
-                <p className="muted">Try adjusting your search criteria</p>
-              </div>
-            )}
-          </div>
-
-          {/* Right: details */}
-          {selectedJob && (
-            <aside className="col side sticky">
-              <div className="card">
-                <div className="row space-between align-center solid-bg header-pad">
-                  <div className="row align-center gap-12">
-                    <div className="header-icon">
-                      <Briefcase className="icon-sm white" />
+        <section className="explorer-results-shell" data-animate="fade-stagger">
+          <div className={`explorer-layout ${selectedJob ? 'explorer-layout--split' : ''}`}>
+            <div className="explorer-results">
+              {Object.keys(groupedJobs).length ? (
+                Object.keys(groupedJobs).map((division) => (
+                  <div key={division} className="explorer-group">
+                    <div className="explorer-group__header">
+                      <h3 className="explorer-group__title">{division}</h3>
+                      <span className="explorer-group__count">{groupedJobs[division].length} roles</span>
                     </div>
-                    <div>
-                      <h3 className="title-md">{selectedJob.title}</h3>
-                      <p className="muted row align-center">
-                        <MapPin className="icon-xs mr-6" />
-                        {selectedJob.division}
-                      </p>
+                    <div className="explorer-card-grid">
+                      {groupedJobs[division].map((job) => {
+                        const isSelected = selectedJob && selectedJob.id === job.id;
+                        const similarity = myPosition ? simScore(myPosition, job) : null;
+                        const toneClass = similarity != null ? getSimilarityTone(similarity) : 'tone-neutral';
+                        const badge = similarity != null ? getSimilarityBadge(similarity) : null;
+
+                        return (
+                          <button
+                            key={job.id}
+                            type="button"
+                            className={`explorer-card ${toneClass} ${isSelected ? 'is-active' : ''}`}
+                            onClick={() => setSelectedJob(job)}
+                            aria-pressed={isSelected}
+                            title={`Open ${job.title}`}
+                          >
+                            <span className="explorer-card__title">{job.title}</span>
+                            <span className="explorer-card__meta">{job.division}</span>
+                            {badge && <span className={`explorer-card__badge ${badge.color}`}>{badge.label}</span>}
+                          </button>
+                        );
+                      })}
                     </div>
                   </div>
-                  <button
-                    className="icon-button"
-                    onClick={() => setSelectedJob(null)}
-                    aria-label="Close details"
-                  >
+                ))
+              ) : (
+                <div className="explorer-empty">
+                  <Users className="icon-xl" />
+                  <p>No roles match your filters just yet. Try a different combination.</p>
+                </div>
+              )}
+            </div>
+
+            {selectedJob && (
+              <aside className="explorer-detail" aria-live="polite">
+                <div className="explorer-detail__header">
+                  <div className="explorer-detail__icon" aria-hidden="true">
+                    <Briefcase className="icon-sm" />
+                  </div>
+                  <div>
+                    <h3 className="explorer-detail__title">{selectedJob.title}</h3>
+                    <p className="explorer-detail__subtitle">
+                      <MapPin className="icon-xs" />
+                      {selectedJob.division}
+                    </p>
+                  </div>
+                  <button className="icon-button" onClick={() => setSelectedJob(null)} aria-label="Close details">
                     <X className="icon-sm" />
                   </button>
                 </div>
 
-                <div className="pad scroll-300">
-                  {/* Save as My Position + quick planner */}
-                  <div className="row gap-12 mb-16">
-                    <button
-                      className="btn"
-                      onClick={() => setMyPositionTitle(selectedJob.title)}
-                      title="Save this as My Position"
-                    >
-                      Set as My Position
+                <div className="explorer-detail__body">
+                  <div className="explorer-detail__quick-actions">
+                    <button className="chip" onClick={() => setMyPositionTitle(selectedJob.title)}>
+                      Save as My Position
                     </button>
                     <button
-                      className="btn"
+                      className="chip"
                       onClick={() =>
                         navigate('/roadmap', {
                           state: { currentTitle: selectedJob.title },
                         })
                       }
-                      title="Use this as your Current job in roadmap"
                     >
-                      Use as Current
+                      Set as Current in Roadmap
                     </button>
                     <button
-                      className="btn"
+                      className="chip"
                       onClick={() =>
                         navigate('/roadmap', {
                           state: {
@@ -489,42 +324,36 @@ const JobSkillsMatcher = () => {
                           },
                         })
                       }
-                      title="Use this as your Target job in roadmap"
                     >
-                      Use as Target
+                      Plan as Target Role
                     </button>
                   </div>
 
-                  {/* Description */}
-                  <section className="mb-16">
-                    <h4 className="text-600 mb-8">Job Description</h4>
-                    <p className="muted text-sm lh">{selectedJob.description}</p>
+                  <section className="explorer-detail__section">
+                    <h4>Role snapshot</h4>
+                    <p>{selectedJob.description}</p>
                   </section>
 
-                  {/* Skills (split by type) */}
-                  <section className="mb-16">
-                    <h4 className="text-600 mb-8">Skills Profile</h4>
-                    <div className="column gap-8">
+                  <section className="explorer-detail__section">
+                    <h4>Skill profile</h4>
+                    <div className="explorer-detail__skills">
                       {selectedJob.skillOrder.length ? (
                         <>
                           {selectedJobSkillsByType.functional.length > 0 && (
                             <div>
-                              <h5 className="text-sm text-600 mb-6">Functional</h5>
+                              <h5>Functional</h5>
                               {selectedJobSkillsByType.functional.map((name, i) => {
                                 const val = selectedJob.skillMap[name] ?? 0;
                                 const def = selectedJob.skillDefByName?.[name];
                                 return (
-                                  <div key={name + i}>
-                                    <div className="row space-between">
-                                      <span className="muted text-sm"><strong>{name}</strong></span>
-                                      <span className="text-sm text-600">{val}/5</span>
+                                  <div key={name + i} className="skill-bar">
+                                    <div className="skill-bar__meta">
+                                      <span>{name}</span>
+                                      <span>{val}/5</span>
                                     </div>
-                                    {def && <div className="text-xs muted mb-4">{def}</div>}
+                                    {def && <div className="skill-bar__description">{def}</div>}
                                     <div className="bar">
-                                      <div
-                                        className="bar-fill blue"
-                                        style={{ width: (val / 5) * 100 + '%' }}
-                                      />
+                                      <div className="bar-fill blue" style={{ width: (val / 5) * 100 + '%' }} />
                                     </div>
                                   </div>
                                 );
@@ -533,22 +362,38 @@ const JobSkillsMatcher = () => {
                           )}
                           {selectedJobSkillsByType.soft.length > 0 && (
                             <div>
-                              <h5 className="text-sm text-600 mb-6">Soft</h5>
+                              <h5>Soft</h5>
                               {selectedJobSkillsByType.soft.map((name, i) => {
                                 const val = selectedJob.skillMap[name] ?? 0;
                                 const def = selectedJob.skillDefByName?.[name];
                                 return (
-                                  <div key={name + i}>
-                                    <div className="row space-between">
-                                      <span className="muted text-sm"><strong>{name}</strong></span>
-                                      <span className="text-sm text-600">{val}/5</span>
+                                  <div key={name + i} className="skill-bar">
+                                    <div className="skill-bar__meta">
+                                      <span>{name}</span>
+                                      <span>{val}/5</span>
                                     </div>
-                                    {def && <div className="text-xs muted mb-4">{def}</div>}
+                                    {def && <div className="skill-bar__description">{def}</div>}
                                     <div className="bar">
-                                      <div
-                                        className="bar-fill blue"
-                                        style={{ width: (val / 5) * 100 + '%' }}
-                                      />
+                                      <div className="bar-fill blue" style={{ width: (val / 5) * 100 + '%' }} />
+                                    </div>
+                                  </div>
+                                );
+                              })}
+                            </div>
+                          )}
+                          {selectedJobSkillsByType.unknown.length > 0 && (
+                            <div>
+                              <h5>Other</h5>
+                              {selectedJobSkillsByType.unknown.map((name, i) => {
+                                const val = selectedJob.skillMap[name] ?? 0;
+                                return (
+                                  <div key={name + i} className="skill-bar">
+                                    <div className="skill-bar__meta">
+                                      <span>{name}</span>
+                                      <span>{val}/5</span>
+                                    </div>
+                                    <div className="bar">
+                                      <div className="bar-fill blue" style={{ width: (val / 5) * 100 + '%' }} />
                                     </div>
                                   </div>
                                 );
@@ -557,105 +402,70 @@ const JobSkillsMatcher = () => {
                           )}
                         </>
                       ) : (
-                        <p className="muted text-sm">No skill data available for this title.</p>
+                        <p>No skill data available for this title.</p>
                       )}
                     </div>
                   </section>
 
-                  {/* Similar (to the selected job) */}
-                  <section>
-                    <h4 className="text-600 mb-8 row align-center">
-                      <TrendingUp className="icon-sm mr-8 green" />
-                      Similar Career Opportunities
+                  <section className="explorer-detail__section">
+                    <h4 className="explorer-detail__section-title">
+                      <TrendingUp className="icon-sm" /> Similar pathways
                     </h4>
 
                     {matchingJobsForSelected.length > 0 ? (
-                      <div className="column gap-8 scroll-180">
+                      <div className="explorer-similar-list">
                         {matchingJobsForSelected.map((job) => {
                           const badge = getSimilarityBadge(job.similarity);
-                          const exp = explainMatch(selectedJob, job);
-                          const sFunc = exp.strengths.filter((s) => s.type === 'functional').map((s) => s.name).join(', ');
-                          const sSoft = exp.strengths.filter((s) => s.type === 'soft').map((s) => s.name).join(', ');
-                          const gFunc = exp.gaps.filter((g) => g.type === 'functional').map((g) => `${g.name} (+${g.gap})`).join(', ');
-                          const gSoft = exp.gaps.filter((g) => g.type === 'soft').map((g) => `${g.name} (+${g.gap})`).join(', ');
+                          const toneClass = getSimilarityTone(job.similarity);
+                          const strengths = job.summary.strengths.map((s) => s.name).join(', ');
+                          const gaps = job.summary.gaps.map((g) => `${g.name} (+${g.gap})`).join(', ');
                           return (
-                            <div
-                              key={job.id}
-                              className={getSimilarityColor(job.similarity)}
-                            >
-                              <div className="row space-between mb-6">
-                                <h5 className="text-sm text-600">{job.title}</h5>
+                            <div key={job.id} className={`explorer-similar ${toneClass}`}>
+                              <div className="explorer-similar__header">
+                                <h5>{job.title}</h5>
                                 <span className={badge.color}>{badge.label}</span>
                               </div>
-                              <p className="text-xs muted mb-8">{job.division}</p>
-                              {(exp.strengths.length > 0 || exp.gaps.length > 0) && (
-                                <div className="text-xs muted mb-8">
-                                  {sFunc && <div>Strengths (Functional): {sFunc}</div>}
-                                  {sSoft && <div>Strengths (Soft): {sSoft}</div>}
-                                  {gFunc && <div>Gaps (Functional): {gFunc}</div>}
-                                  {gSoft && <div>Gaps (Soft): {gSoft}</div>}
+                              <p className="explorer-similar__meta">{job.division}</p>
+                              {(strengths || gaps) && (
+                                <div className="explorer-similar__summary">
+                                  {strengths && (
+                                    <div>
+                                      <strong>Strengths:</strong> {strengths}
+                                    </div>
+                                  )}
+                                  {gaps && (
+                                    <div>
+                                      <strong>Gaps:</strong> {gaps}
+                                    </div>
+                                  )}
                                 </div>
                               )}
-                              <div className="row gap-12">
-                                <button
-                                  className="btn primary full row center"
-                                  onClick={() =>
-                                    navigate('/roadmap', {
-                                      state: { currentTitle: selectedJob.title, targetTitle: job.title },
-                                    })
-                                  }
-                                  title="Open roadmap with these roles"
-                                >
-                                  <Route className="icon-xs mr-6 white" />
-                                  Plan in Roadmap
-                                </button>
-                              </div>
+                              <button
+                                className="chip chip--ghost"
+                                onClick={() =>
+                                  navigate('/roadmap', {
+                                    state: { currentTitle: selectedJob.title, targetTitle: job.title },
+                                  })
+                                }
+                              >
+                                Plan in Roadmap
+                              </button>
                             </div>
                           );
                         })}
                       </div>
                     ) : (
-                      <div className="empty small">
-                        <TrendingUp className="icon-md muted" />
-                        <p className="text-sm muted mt-6">No similar positions found</p>
+                      <div className="explorer-empty explorer-empty--inline">
+                        <TrendingUp className="icon-md" />
+                        <p>No similar positions found yet.</p>
                       </div>
                     )}
                   </section>
                 </div>
-              </div>
-            </aside>
-          )}
-        </div>
-
-        {/* Roadmap call-to-action */}
-        <h2 className="section-h2">Explorer Roadmap Planner</h2>
-        <div className="card section" style={{ marginTop: 8 }}>
-          <p className="muted text-sm">
-            Build your transition plan on the dedicated roadmap page. We'll carry over your saved starting role
-            and any selected targets so you can see the full skill story.
-          </p>
-          <div className="row gap-12 wrap" style={{ marginTop: 12 }}>
-            <Link to="/roadmap" state={roadmapLinkState} className="btn primary">
-              <Route className="icon-xs mr-6 white" />
-              Open roadmap planner
-            </Link>
-            {selectedJob && (
-              <Link
-                to="/roadmap"
-                state={selectedJobRoadmapState}
-                className="btn ghost"
-              >
-                <Route className="icon-xs mr-6" />
-                Plan with {selectedJob.title}
-              </Link>
+              </aside>
             )}
           </div>
-          {!myPosition && (
-            <p className="muted text-xs" style={{ marginTop: 12 }}>
-              Tip: Save your current role in the My Position section above to prefill the planner automatically.
-            </p>
-          )}
-        </div>
+        </section>
       </div>
     </div>
   );

--- a/src/hooks/useRevealOnScroll.js
+++ b/src/hooks/useRevealOnScroll.js
@@ -1,0 +1,50 @@
+import { useEffect } from 'react';
+
+const DEFAULT_DEPENDENCIES = [];
+
+export default function useRevealOnScroll(...deps) {
+  const dependencies = deps.length > 0 ? deps : DEFAULT_DEPENDENCIES;
+  const trigger = dependencies.length
+    ? dependencies.map((dep) => String(dep ?? 'null')).join('|')
+    : 'static';
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof document === 'undefined') return undefined;
+
+    const elements = Array.from(document.querySelectorAll('[data-animate]'));
+    if (!elements.length) return undefined;
+
+    const prefersReducedMotion = window.matchMedia
+      ? window.matchMedia('(prefers-reduced-motion: reduce)').matches
+      : false;
+
+    if (prefersReducedMotion) {
+      elements.forEach((el) => el.setAttribute('data-animate-ready', ''));
+      return undefined;
+    }
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting || entry.intersectionRatio > 0) {
+            entry.target.setAttribute('data-animate-ready', '');
+            observer.unobserve(entry.target);
+          }
+        });
+      },
+      {
+        threshold: 0.1,
+        rootMargin: '0px 0px -10% 0px',
+      }
+    );
+
+    elements.forEach((el) => {
+      if (el.hasAttribute('data-animate-ready')) return;
+      observer.observe(el);
+    });
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [trigger]);
+}

--- a/src/styles/components/buttons.css
+++ b/src/styles/components/buttons.css
@@ -82,6 +82,23 @@
   outline-offset: 2px;
 }
 
+.button--inverse {
+  background: var(--color-text-inverse);
+  color: var(--color-rich-purple);
+  border-color: transparent;
+  box-shadow: 0 22px 45px rgba(0, 0, 0, 0.28);
+}
+
+.button--inverse:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 26px 52px rgba(0, 0, 0, 0.3);
+}
+
+.button--inverse:focus-visible {
+  outline: 3px solid var(--color-vibrant-cyan);
+  outline-offset: 2px;
+}
+
 .button--fun,
 .btn.fun {
   background: var(--color-rich-red);

--- a/src/styles/components/hero.css
+++ b/src/styles/components/hero.css
@@ -8,7 +8,7 @@
   position: relative;
   overflow: hidden;
   padding: 7rem 0 5rem;
-  background: var(--color-rich-purple);
+  background: linear-gradient(135deg, rgba(52, 12, 96, 1), rgba(27, 9, 58, 1));
   color: var(--color-text-inverse);
 }
 
@@ -26,6 +26,7 @@
   top: -200px;
   right: -160px;
   background: var(--color-sensitive-blue);
+  animation: heroGlowShift 14s ease-in-out infinite;
 }
 
 .hero::after {
@@ -34,6 +35,7 @@
   bottom: -200px;
   left: -160px;
   background: var(--color-sensitive-pink);
+  animation: heroGlowShift 12s ease-in-out infinite reverse;
 }
 
 .hero__inner {
@@ -89,6 +91,25 @@
   min-width: 180px;
 }
 
+.hero__content[data-animate]:not([data-animate-ready]) .hero__title,
+.hero__content[data-animate]:not([data-animate-ready]) .hero__text,
+.hero__content[data-animate]:not([data-animate-ready]) .hero__actions {
+  opacity: 0;
+  transform: translateY(18px);
+}
+
+.hero__content[data-animate-ready] .hero__title {
+  animation: heroFadeIn 0.8s ease both;
+}
+
+.hero__content[data-animate-ready] .hero__text {
+  animation: heroFadeIn 0.9s ease both;
+}
+
+.hero__content[data-animate-ready] .hero__actions {
+  animation: heroFadeIn 1s ease both;
+}
+
 .hero__media {
   position: relative;
   width: 100%;
@@ -106,6 +127,7 @@
   border: 4px solid var(--color-vibrant-cyan);
   box-shadow: 0 36px 68px rgba(0, 0, 0, 0.25);
   overflow: hidden;
+  animation: heroFloat 10s ease-in-out infinite;
 }
 
 .hero__animation::before,
@@ -175,6 +197,15 @@
   animation: heroPulse 6s infinite ease-in-out;
 }
 
+.hero__media::after {
+  content: '';
+  position: absolute;
+  inset: 12%;
+  border-radius: 28px;
+  border: 2px dashed rgba(255, 255, 255, 0.35);
+  animation: heroOrbit 18s linear infinite;
+}
+
 @keyframes heroOrbit {
   0%,
   100% {
@@ -205,6 +236,39 @@
   }
   66% {
     transform: translate(-6%, 10%);
+  }
+}
+
+@keyframes heroGlowShift {
+  0%,
+  100% {
+    transform: scale(1) translate(0, 0);
+    opacity: 0.4;
+  }
+  50% {
+    transform: scale(1.1) translate(-5%, 4%);
+    opacity: 0.55;
+  }
+}
+
+@keyframes heroFadeIn {
+  0% {
+    opacity: 0;
+    transform: translateY(18px);
+  }
+  100% {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes heroFloat {
+  0%,
+  100% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(-10px);
   }
 }
 

--- a/src/styles/layouts/job-skills-matcher.css
+++ b/src/styles/layouts/job-skills-matcher.css
@@ -5,6 +5,956 @@
  * Merck color world palette, avoiding gradients while keeping high contrast.
  */
 
+@keyframes experienceGlow {
+  0%,
+  100% {
+    transform: translate3d(0, 0, 0) scale(1);
+    opacity: 0.35;
+  }
+  50% {
+    transform: translate3d(8%, -6%, 0) scale(1.08);
+    opacity: 0.5;
+  }
+}
+
+@keyframes fadeSlideUp {
+  0% {
+    opacity: 0;
+    transform: translate3d(0, 24px, 0);
+  }
+  100% {
+    opacity: 1;
+    transform: translate3d(0, 0, 0);
+  }
+}
+
+@keyframes floatPulse {
+  0%,
+  100% {
+    transform: translate3d(0, 0, 0);
+  }
+  50% {
+    transform: translate3d(0, -6px, 0);
+  }
+}
+
+[data-animate]:not([data-animate='fade-stagger']) {
+  opacity: 0;
+  transform: translate3d(0, 18px, 0);
+  will-change: opacity, transform;
+}
+
+[data-animate]:not([data-animate='fade-stagger'])[data-animate-ready] {
+  opacity: 1;
+  transform: translate3d(0, 0, 0);
+}
+
+[data-animate='fade-slide'][data-animate-ready] {
+  animation: fadeSlideUp 0.7s ease forwards;
+}
+
+[data-animate='fade-up'][data-animate-ready] {
+  animation: fadeSlideUp 0.7s ease 0.1s forwards;
+}
+
+[data-animate='fade-stagger'] > * {
+  opacity: 0;
+  transform: translate3d(0, 26px, 0);
+}
+
+[data-animate='fade-stagger'][data-animate-ready] > * {
+  animation: fadeSlideUp 0.7s ease forwards;
+}
+
+[data-animate='fade-stagger'][data-animate-ready] > *:nth-child(2) {
+  animation-delay: 0.08s;
+}
+
+[data-animate='fade-stagger'][data-animate-ready] > *:nth-child(3) {
+  animation-delay: 0.14s;
+}
+
+[data-animate='fade-stagger'][data-animate-ready] > *:nth-child(4) {
+  animation-delay: 0.2s;
+}
+
+[data-animate='fade-stagger'][data-animate-ready] > *:nth-child(5) {
+  animation-delay: 0.26s;
+}
+
+[data-animate='fade-stagger'][data-animate-ready] > *:nth-child(6) {
+  animation-delay: 0.32s;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  [data-animate],
+  [data-animate] > * {
+    animation: none !important;
+    opacity: 1 !important;
+    transform: none !important;
+  }
+}
+
+.experience-hero {
+  position: relative;
+  padding: 2.75rem 2.5rem;
+  border-radius: 28px;
+  border: 2px solid rgba(255, 255, 255, 0.18);
+  overflow: hidden;
+  background: var(--color-rich-purple);
+  color: var(--color-text-inverse);
+  box-shadow: 0 30px 80px rgba(28, 12, 68, 0.35);
+}
+
+.experience-hero::before,
+.experience-hero::after {
+  content: '';
+  position: absolute;
+  width: 260px;
+  height: 260px;
+  border-radius: 50%;
+  background: var(--color-sensitive-pink);
+  filter: blur(8px);
+  opacity: 0.42;
+  animation: experienceGlow 12s ease-in-out infinite;
+}
+
+.experience-hero::before {
+  top: -90px;
+  right: -60px;
+}
+
+.experience-hero::after {
+  bottom: -120px;
+  left: -40px;
+  background: var(--color-sensitive-blue);
+  animation-delay: 0.5s;
+}
+
+.experience-hero--explorer {
+  background: linear-gradient(145deg, var(--color-rich-purple), #2d0c50 65%, #401c7a 100%);
+}
+
+.experience-hero__header {
+  display: flex;
+  gap: 1.5rem;
+  align-items: center;
+  position: relative;
+  z-index: 1;
+}
+
+.experience-hero__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 60px;
+  height: 60px;
+  border-radius: 20px;
+  background: rgba(255, 255, 255, 0.12);
+  box-shadow: 0 18px 40px rgba(0, 0, 0, 0.24);
+  animation: floatPulse 6s ease-in-out infinite;
+}
+
+.experience-hero__title {
+  font-size: clamp(2rem, 3.2vw, 3rem);
+  margin: 0;
+  letter-spacing: -0.01em;
+}
+
+.experience-hero__subtitle {
+  margin: 0.5rem 0 0;
+  max-width: 540px;
+  color: rgba(255, 255, 255, 0.82);
+  font-size: 1.05rem;
+}
+
+.experience-hero__grid {
+  display: grid;
+  margin-top: 2.5rem;
+  gap: 2rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  position: relative;
+  z-index: 1;
+}
+
+.experience-hero__status-card {
+  background: rgba(12, 7, 28, 0.36);
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  border-radius: 20px;
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.06);
+}
+
+.experience-hero__status-label {
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  letter-spacing: 0.1em;
+  color: rgba(255, 255, 255, 0.72);
+}
+
+.experience-hero__status-value {
+  font-size: 1.2rem;
+  font-weight: 700;
+  color: var(--color-sensitive-yellow);
+}
+
+.experience-hero__status-text {
+  margin: 0;
+  color: rgba(255, 255, 255, 0.8);
+  font-size: 0.95rem;
+}
+
+.experience-hero__actions {
+  display: inline-flex;
+  flex-direction: column;
+  gap: 0.85rem;
+}
+
+.experience-hero__actions .button {
+  width: fit-content;
+}
+
+.chip,
+.chip-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  padding: 0.45rem 0.9rem;
+  border-radius: 999px;
+  font-size: 0.82rem;
+  font-weight: 600;
+  text-decoration: none;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease,
+    color 0.2s ease;
+}
+
+.chip {
+  background: var(--surface);
+  color: var(--color-rich-purple);
+  border: 1px solid var(--color-rich-purple);
+}
+
+.chip-link {
+  background: rgba(255, 255, 255, 0.14);
+  border: 1px solid rgba(255, 255, 255, 0.22);
+  color: var(--color-text-inverse);
+}
+
+.chip--ghost {
+  background: transparent;
+  border: 1px dashed var(--color-rich-purple);
+  color: var(--color-rich-purple);
+}
+
+.chip--outline {
+  background: rgba(255, 255, 255, 0.6);
+  color: var(--color-rich-purple);
+  border: 1px solid var(--color-rich-purple);
+}
+
+.chip:hover,
+.chip-link:hover,
+.chip--ghost:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 14px 30px rgba(0, 0, 0, 0.16);
+}
+
+.explorer-panel {
+  margin-top: 2.5rem;
+  padding: 2rem;
+  border-radius: 24px;
+  background: var(--surface);
+  border: 2px solid var(--color-border-soft);
+  box-shadow: 0 18px 40px rgba(9, 22, 50, 0.12);
+}
+
+.explorer-panel__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 1.5rem;
+  align-items: flex-start;
+  margin-bottom: 1.5rem;
+}
+
+.explorer-filter-grid {
+  display: grid;
+  gap: 1.25rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.field--elevated .field__control {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.field__label {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--color-rich-purple);
+}
+
+.field__icon {
+  position: absolute;
+  left: 14px;
+  color: var(--muted);
+}
+
+.input--elevated {
+  padding-left: 46px;
+  background: linear-gradient(145deg, rgba(255, 255, 255, 0.92), rgba(244, 243, 255, 0.92));
+  border-radius: 16px;
+  border: 2px solid var(--color-border-soft);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.8);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.input--elevated:focus {
+  border-color: var(--color-rich-purple);
+  box-shadow: 0 0 0 3px rgba(141, 69, 255, 0.25);
+}
+
+.explorer-results-shell {
+  margin-top: 2.5rem;
+}
+
+.explorer-layout {
+  display: grid;
+  gap: 2rem;
+}
+
+.explorer-layout--split {
+  grid-template-columns: minmax(0, 2fr) minmax(280px, 1fr);
+}
+
+.explorer-results {
+  display: flex;
+  flex-direction: column;
+  gap: 1.75rem;
+}
+
+.explorer-group {
+  padding: 1.75rem;
+  border-radius: 24px;
+  background: var(--surface);
+  border: 2px solid var(--color-border-soft);
+  box-shadow: 0 12px 34px rgba(15, 18, 54, 0.1);
+}
+
+.explorer-group__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.explorer-group__title {
+  margin: 0;
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: var(--color-rich-purple);
+}
+
+.explorer-group__count {
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+.explorer-card-grid {
+  display: grid;
+  gap: 1.2rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.explorer-card {
+  position: relative;
+  border-radius: 22px;
+  padding: 1rem 1.2rem 1.15rem;
+  background: var(--surface-2);
+  border: 2px solid transparent;
+  text-align: left;
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  transition: transform 0.25s ease, box-shadow 0.25s ease, border-color 0.25s ease,
+    background 0.3s ease;
+  box-shadow: 0 12px 28px rgba(21, 12, 74, 0.12);
+}
+
+.explorer-card::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: 20px;
+  background: rgba(255, 255, 255, 0.3);
+  opacity: 0;
+  transition: opacity 0.25s ease;
+}
+
+.explorer-card__title {
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--color-rich-purple);
+}
+
+.explorer-card__meta {
+  font-size: 0.82rem;
+  color: var(--muted);
+}
+
+.explorer-card__badge {
+  align-self: flex-start;
+  margin-top: 0.35rem;
+}
+
+.explorer-card:hover,
+.explorer-card.is-active {
+  transform: translateY(-4px);
+  box-shadow: 0 20px 42px rgba(18, 21, 64, 0.18);
+}
+
+.explorer-card:hover::before,
+.explorer-card.is-active::before {
+  opacity: 0.18;
+}
+
+.tone-green {
+  border-color: rgba(30, 170, 115, 0.38);
+}
+
+.tone-yellow {
+  border-color: rgba(252, 214, 98, 0.48);
+}
+
+.tone-lilac {
+  border-color: rgba(141, 89, 255, 0.45);
+}
+
+.tone-blue {
+  border-color: rgba(83, 182, 255, 0.4);
+}
+
+.tone-red {
+  border-color: rgba(218, 67, 103, 0.45);
+}
+
+.tone-neutral {
+  border-color: var(--color-border-soft);
+}
+
+.explorer-empty {
+  padding: 3rem 2rem;
+  border-radius: 24px;
+  border: 2px dashed var(--color-border-soft);
+  background: var(--surface);
+  text-align: center;
+  color: var(--muted);
+  display: grid;
+  place-items: center;
+  gap: 1rem;
+}
+
+.explorer-empty svg {
+  color: var(--color-rich-purple);
+  opacity: 0.3;
+}
+
+.explorer-empty--inline {
+  padding: 1.5rem;
+  border-radius: 18px;
+  border-style: dashed;
+}
+
+.explorer-detail {
+  border-radius: 26px;
+  border: 2px solid var(--color-border-soft);
+  background: linear-gradient(145deg, rgba(255, 255, 255, 0.98), rgba(243, 242, 255, 0.98));
+  box-shadow: 0 28px 52px rgba(12, 16, 50, 0.22);
+  position: sticky;
+  top: 2rem;
+  align-self: start;
+  max-height: calc(100vh - 4rem);
+  display: flex;
+  flex-direction: column;
+}
+
+.explorer-detail__header {
+  display: flex;
+  align-items: flex-start;
+  gap: 1rem;
+  padding: 1.5rem 1.5rem 1.25rem;
+  border-bottom: 1px solid rgba(28, 20, 60, 0.1);
+}
+
+.explorer-detail__icon {
+  width: 48px;
+  height: 48px;
+  border-radius: 16px;
+  background: var(--color-sensitive-blue);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--color-rich-purple);
+}
+
+.explorer-detail__title {
+  margin: 0;
+  font-size: 1.2rem;
+  font-weight: 700;
+  color: var(--color-rich-purple);
+}
+
+.explorer-detail__subtitle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  margin: 0.35rem 0 0;
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.explorer-detail__body {
+  overflow-y: auto;
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.75rem;
+}
+
+.explorer-detail__quick-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.explorer-detail__section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.explorer-detail__section h4 {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 700;
+  color: var(--color-rich-purple);
+}
+
+.explorer-detail__skills {
+  display: grid;
+  gap: 1rem;
+}
+
+.skill-bar {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.skill-bar__meta {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.9rem;
+  color: var(--color-rich-purple);
+}
+
+.skill-bar__description {
+  font-size: 0.75rem;
+  color: var(--muted);
+}
+
+.explorer-detail__section-title {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 1rem;
+  color: var(--color-rich-purple);
+}
+
+.explorer-similar-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.explorer-similar {
+  border-radius: 20px;
+  border: 2px solid rgba(110, 94, 208, 0.2);
+  background: rgba(255, 255, 255, 0.86);
+  padding: 1.1rem 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+}
+
+.explorer-similar__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+.explorer-similar__meta {
+  font-size: 0.82rem;
+  color: var(--muted);
+}
+
+.explorer-similar__summary {
+  font-size: 0.8rem;
+  color: var(--color-rich-purple);
+  display: grid;
+  gap: 0.35rem;
+}
+
+.explorer-similar.tone-green {
+  border-color: rgba(32, 160, 110, 0.45);
+}
+
+.explorer-similar.tone-yellow {
+  border-color: rgba(248, 204, 90, 0.5);
+}
+
+.explorer-similar.tone-lilac {
+  border-color: rgba(141, 89, 255, 0.48);
+}
+
+.explorer-similar.tone-blue {
+  border-color: rgba(83, 182, 255, 0.45);
+}
+
+.roadmap-panel {
+  margin-top: 3rem;
+  background: var(--surface);
+  border: 2px solid var(--color-border-soft);
+  border-radius: 26px;
+  box-shadow: 0 22px 56px rgba(12, 22, 70, 0.12);
+  padding: 2.25rem;
+}
+
+.roadmap-panel__grid {
+  display: grid;
+  gap: 2rem;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.roadmap-card-block {
+  background: linear-gradient(150deg, rgba(255, 255, 255, 0.95), rgba(244, 243, 255, 0.95));
+  border-radius: 22px;
+  border: 1px solid rgba(120, 112, 210, 0.18);
+  padding: 1.75rem;
+  box-shadow: 0 18px 36px rgba(18, 28, 70, 0.12);
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.roadmap-card-block__header {
+  display: flex;
+  gap: 0.9rem;
+  align-items: flex-start;
+  color: var(--color-rich-purple);
+}
+
+.roadmap-card-block__header h2 {
+  margin: 0;
+  font-size: 1.25rem;
+}
+
+.roadmap-card-block__header p {
+  margin: 0.25rem 0 0;
+  font-size: 0.9rem;
+  color: var(--muted);
+}
+
+.roadmap-card-block__body {
+  display: flex;
+  flex-direction: column;
+  gap: 1.1rem;
+}
+
+.roadmap-card-block__body--grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.1rem;
+}
+
+.roadmap-card-block__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.roadmap-card-block__tips {
+  display: flex;
+  gap: 0.65rem;
+  align-items: flex-start;
+  padding: 0.9rem 1rem;
+  border-radius: 16px;
+  background: rgba(141, 89, 255, 0.12);
+  color: var(--color-rich-purple);
+  font-size: 0.85rem;
+}
+
+.roadmap-insights {
+  margin-top: 2.5rem;
+  padding: 2.25rem;
+  border-radius: 28px;
+  border: 2px solid rgba(141, 89, 255, 0.18);
+  background: linear-gradient(165deg, rgba(255, 255, 255, 0.96), rgba(240, 238, 255, 0.96));
+  box-shadow: 0 30px 60px rgba(15, 24, 60, 0.18);
+  display: flex;
+  flex-direction: column;
+  gap: 1.75rem;
+}
+
+.roadmap-insights__header {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+}
+
+.roadmap-insights__icon {
+  width: 44px;
+  height: 44px;
+  border-radius: 14px;
+  background: var(--color-sensitive-blue);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--color-rich-purple);
+  box-shadow: 0 10px 20px rgba(80, 120, 255, 0.25);
+}
+
+.roadmap-insights__header h2 {
+  margin: 0;
+  font-size: 1.4rem;
+  color: var(--color-rich-purple);
+}
+
+.roadmap-insights__header p {
+  margin: 0.25rem 0 0;
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+.roadmap-insights__meta {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  align-items: center;
+}
+
+.roadmap-insights__divider {
+  width: 1px;
+  height: 44px;
+  background: rgba(141, 89, 255, 0.24);
+}
+
+.roadmap-insights__label {
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  letter-spacing: 0.12em;
+  color: var(--muted);
+}
+
+.roadmap-insights__value {
+  display: block;
+  margin-top: 0.25rem;
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: var(--color-rich-purple);
+}
+
+.roadmap-group {
+  border: 2px solid rgba(141, 89, 255, 0.18);
+  border-radius: 22px;
+  padding: 1.5rem;
+  background: rgba(255, 255, 255, 0.95);
+  margin-bottom: 1.25rem;
+}
+
+.roadmap-group__header {
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+  font-weight: 700;
+  color: var(--color-rich-purple);
+  margin-bottom: 1rem;
+}
+
+.roadmap-group__icon {
+  width: 32px;
+  height: 32px;
+  border-radius: 12px;
+  background: rgba(141, 89, 255, 0.14);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.roadmap-group__count {
+  margin-left: auto;
+  font-size: 0.8rem;
+  color: var(--muted);
+}
+
+.roadmap-group__grid {
+  display: grid;
+  gap: 1.1rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.roadmap-card {
+  border-radius: 20px;
+  border: 1px solid rgba(141, 89, 255, 0.2);
+  background: rgba(255, 255, 255, 0.96);
+  padding: 1.1rem 1.25rem;
+  box-shadow: 0 12px 30px rgba(20, 30, 70, 0.12);
+  display: flex;
+  flex-direction: column;
+  gap: 0.8rem;
+}
+
+.roadmap-card__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+.roadmap-card__header h4 {
+  margin: 0;
+  font-size: 1rem;
+  color: var(--color-rich-purple);
+}
+
+.roadmap-card__range {
+  font-size: 0.82rem;
+  color: var(--muted);
+}
+
+.roadmap-card__gap {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--color-rich-purple);
+}
+
+.roadmap-card__footer {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.roadmap-card__label {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--muted);
+}
+
+.roadmap-card__training {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.8rem;
+  color: var(--color-rich-purple);
+}
+
+.roadmap-results {
+  margin-top: 2.75rem;
+}
+
+.roadmap-recommendations {
+  margin-top: 3rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.roadmap-recommendations__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1.25rem;
+}
+
+.roadmap-recommendation {
+  border-radius: 22px;
+  border: 1px solid rgba(141, 89, 255, 0.2);
+  background: rgba(255, 255, 255, 0.95);
+  padding: 1.3rem 1.5rem;
+  box-shadow: 0 16px 40px rgba(16, 26, 70, 0.14);
+  display: flex;
+  flex-direction: column;
+  gap: 0.8rem;
+}
+
+.roadmap-recommendation__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+}
+
+.roadmap-recommendation__summary {
+  font-size: 0.85rem;
+  color: var(--color-rich-purple);
+  display: grid;
+  gap: 0.35rem;
+}
+
+.roadmap-recommendation__actions {
+  display: flex;
+  justify-content: flex-start;
+}
+
+.roadmap-recommendations__header .section-h2 {
+  margin: 0;
+}
+@media (max-width: 960px) {
+  .experience-hero {
+    padding: 2.25rem 1.75rem;
+  }
+
+  .experience-hero__grid {
+    grid-template-columns: 1fr;
+  }
+
+  .experience-hero__actions {
+    flex-direction: row;
+    flex-wrap: wrap;
+  }
+
+  .explorer-layout--split {
+    grid-template-columns: 1fr;
+  }
+
+  .explorer-detail {
+    position: static;
+    max-height: none;
+  }
+}
+
+@media (max-width: 640px) {
+  .explorer-panel,
+  .explorer-group {
+    padding: 1.5rem;
+  }
+
+  .explorer-card-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .roadmap-insights__divider {
+    display: none;
+  }
+}
+
 .title-lg { font-size: 26px; font-weight: 700; color: var(--color-rich-purple); }
 .title-md { font-size: 20px; font-weight: 700; color: var(--color-rich-purple); }
 .title-sm { font-size: 16px; font-weight: 600; color: var(--color-rich-purple); }


### PR DESCRIPTION
## Summary
- add a reusable useRevealOnScroll hook and apply it to the home hero, explorer, and roadmap sections so motion plays once elements enter the viewport
- tune hero/explorer CSS to respect the new data-animate workflow and gate text animations until the reveal triggers
- harden roadmap planner shortcuts by resetting the division filter when pre-filling roles from saved positions or recommendations

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ca8a019fa8832d9258793741098645