### PR TITLE
Add scroll-activated function panels to home page

### DIFF
--- a/src/components/FrameworkFunctions.jsx
+++ b/src/components/FrameworkFunctions.jsx
@@ -1,9 +1,5 @@
 import React from 'react';
 
-/**
- * Grid summarising SPH functions with placeholder animations. Animations use
- * CSS classes so future bespoke artwork can drop in without touching markup.
- */
 const FrameworkFunctions = React.forwardRef(function FrameworkFunctions(
   { functions = [] },
   ref,
@@ -27,18 +23,30 @@ const FrameworkFunctions = React.forwardRef(function FrameworkFunctions(
             and Roadmap.
           </p>
         </header>
-        <div className="framework-functions__grid">
+        <div className="framework-functions__list">
           {functions.map((fn) => (
-            <article key={fn.id} className="framework-functions__card">
-              <div
-                className={`framework-functions__animation framework-functions__animation--${fn.animation}`}
-                aria-hidden="true"
-              />
-              <div className="framework-functions__name">{fn.name}</div>
-              <p className="framework-functions__description">{fn.description}</p>
-              <div className="framework-functions__meta">
-                <span className="badge purple">{fn.code}</span>
-                <span>{fn.focus}</span>
+            <article key={fn.id} className="function-showcase" data-animate="fade-slide">
+              <div className="function-showcase__layout">
+                <div className="function-showcase__copy">
+                  <span className="function-showcase__code badge purple">{fn.code}</span>
+                  <h3 className="function-showcase__name">{fn.name}</h3>
+                  <p className="function-showcase__about">{fn.about}</p>
+                  <div className="function-showcase__focus">
+                    <h4 className="function-showcase__focus-title">Focus areas</h4>
+                    <ul className="function-showcase__focus-list">
+                      {fn.focusAreas.map((area) => (
+                        <li key={area.title} className="function-showcase__focus-item">
+                          <span className="function-showcase__focus-heading">{area.title}</span>
+                          <p className="function-showcase__focus-description">{area.description}</p>
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                </div>
+                <div
+                  className={`function-showcase__visual function-showcase__visual--${fn.animation}`}
+                  aria-hidden="true"
+                />
               </div>
             </article>
           ))}

--- a/src/data/frameworkFunctions.js
+++ b/src/data/frameworkFunctions.js
@@ -3,27 +3,74 @@ export const frameworkFunctions = [
     id: 'global-program-management',
     code: 'GPM',
     name: 'Global Program Management',
-    description:
-      'Leads Global Program Teams with agile governance, strategic optionality, and an inclusive mindset so new medicines move forward with urgency and confidence.',
-    focus: 'Program leadership & portfolio orchestration',
+    about:
+      'Global Program Management enables Global Program Teams (GPTs) and the wider organization to develop new medicines with urgency, agility, and impact. By leveraging state-of-the-art program management, GPM fosters strategy optionality, operational excellence, and a one-team winning mindset to maximize pipeline value.',
+    focusAreas: [
+      {
+        title: 'Integrated Asset Strategy Development',
+        description: 'Builds competitive and realistic asset plans aligned with business priorities.',
+      },
+      {
+        title: 'R&D & Asset Strategy Execution',
+        description: 'Drives execution with urgency, agility, and operational excellence to deliver results.',
+      },
+      {
+        title: 'High-Performing Teams',
+        description: 'Cultivates inclusion, HIC behaviors, and cross-functional collaboration to unleash team potential and accelerate success.',
+      },
+    ],
     animation: 'orbit',
   },
   {
     id: 'chief-medical-officer',
     code: 'CMO',
     name: 'Chief Medical Officer Governance & Operations',
-    description:
-      'Safeguards recognised medical and ethical standards throughout human subject research, enabling compliant decision-making from first-in-human to commercial launch.',
-    focus: 'Medical governance & patient safety',
+    about:
+      'CMO Governance & Operations ensures medical governance, ethics, and operational excellence across Healthcare R&D. It safeguards the highest standards in patient safety, medical compliance, and ethical conduct from early research through post-approval, while enabling effective governance forums, decision-making, and operations that maximize impact for patients and the business.',
+    focusAreas: [
+      {
+        title: 'Medical Governance & Compliance',
+        description: 'Upholds global medical and ethical standards across all R&D activities, ensuring integrity, safety, and regulatory compliance.',
+      },
+      {
+        title: 'Governance Forums & Councils',
+        description: 'Operates key bodies such as the Medical Safety & Ethics Board (MSEB), Human Exposure Group (HEG), and Medical Council to drive consistent oversight and alignment.',
+      },
+      {
+        title: 'Patient-Focused Access Models',
+        description: 'Oversees frameworks for Patient Support Programs (PSP) and Early/Post-Approval Access, ensuring ethical patient access to treatments while minimizing risks.',
+      },
+      {
+        title: 'Operational Excellence',
+        description: 'Provides governance, processes, and operational backbone to ensure consistent, transparent, and high-quality decision-making across the medical domain.',
+      },
+      {
+        title: 'Cross-R&D Alignment',
+        description: 'Serves as a unifying function for medical governance across global teams, ensuring regional and local activities align with global standards and strategy.',
+      },
+    ],
     animation: 'pulse',
   },
   {
     id: 'clinical-development-japan',
-    code: 'CDC Japan',
-    name: 'Clinical Development Japan',
-    description:
-      'Executes early- through late-stage clinical programmes in Japan aligned to global strategies while protecting scientific rigour and ethical delivery.',
-    focus: 'Regional clinical excellence',
+    code: 'GPDS',
+    name: 'Global Portfolio & Decision Sciences',
+    about:
+      'GPDS provides an unbiased, high-quality view of the portfolio, acting as a trusted partner for governance and decision-making. Through efficient planning, insights, and coordination, GPDS simplifies processes, enhances strategy execution, and supports value maximization of R&D investments.',
+    focusAreas: [
+      {
+        title: 'Portfolio Management',
+        description: 'Delivers fact-based portfolio assessments and value-maximization options for governance and decision makers.',
+      },
+      {
+        title: 'R&D Governance',
+        description: 'Designs and executes decision schedules that support timely and high-value asset execution.',
+      },
+      {
+        title: 'R&D Planning & Analytics',
+        description: 'Builds an integrated business operations environment combining project, resource, cost, and portfolio data to generate actionable insights and improve productivity.',
+      },
+    ],
     animation: 'wave',
   },
 ];

--- a/src/styles/components/function-showcase.css
+++ b/src/styles/components/function-showcase.css
@@ -1,6 +1,6 @@
 /*
- * Showcase grid summarising the SPH functions. Each block uses the refreshed
- * Merck palette without gradients to create bold yet balanced compositions.
+ * Function showcase panels displayed as scroll-activated stories. Information
+ * lives on the left with supporting motion artwork on the right.
  */
 
 .framework-functions {
@@ -10,7 +10,7 @@
 .framework-functions__header {
   text-align: center;
   max-width: 720px;
-  margin: 0 auto 2.5rem;
+  margin: 0 auto 3rem;
 }
 
 .framework-functions__eyebrow {
@@ -37,48 +37,128 @@
   font-size: 1.05rem;
 }
 
-.framework-functions__grid {
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 1.5rem;
-}
-
-.framework-functions__card {
+.framework-functions__list {
   display: flex;
   flex-direction: column;
-  gap: 1.25rem;
-  padding: 1.75rem 1.5rem;
-  border-radius: 24px;
-  border: 2px solid var(--color-border-soft);
+  gap: 2.75rem;
+}
+
+.function-showcase {
+  border-radius: 32px;
+  border: 1px solid var(--color-border-soft);
   background: var(--surface);
   box-shadow: var(--shadow);
+  padding: 2.5rem;
 }
 
-.framework-functions__animation {
-  width: 100%;
-  aspect-ratio: 5 / 3;
-  border-radius: 20px;
+.function-showcase__layout {
+  display: flex;
+  align-items: stretch;
+  gap: 2.5rem;
+}
+
+.function-showcase__copy {
+  flex: 1 1 360px;
+  display: flex;
+  flex-direction: column;
+  gap: 1.15rem;
+}
+
+.function-showcase__code {
+  align-self: flex-start;
+}
+
+.function-showcase__name {
+  font-size: clamp(1.9rem, 3vw, 2.5rem);
+  color: var(--color-rich-purple);
+  margin: 0;
+}
+
+.function-showcase__about {
+  color: var(--text);
+  line-height: 1.7;
+  margin: 0;
+}
+
+.function-showcase__focus {
+  margin-top: 0.5rem;
+}
+
+.function-showcase__focus-title {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--muted);
+  margin-bottom: 0.5rem;
+}
+
+.function-showcase__focus-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 1rem;
+}
+
+.function-showcase__focus-item {
+  position: relative;
+  padding-left: 1.25rem;
+}
+
+.function-showcase__focus-item::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 0.4rem;
+  bottom: 0.4rem;
+  width: 4px;
+  border-radius: 999px;
+  background: var(--color-sensitive-green);
+}
+
+.function-showcase__focus-heading {
+  display: block;
+  font-weight: 700;
+  color: var(--color-rich-blue);
+}
+
+.function-showcase__focus-description {
+  margin: 0.25rem 0 0;
+  color: var(--text);
+  line-height: 1.6;
+}
+
+.function-showcase__visual {
+  flex: 1 1 320px;
+  max-width: 400px;
+  border-radius: 28px;
   position: relative;
   overflow: hidden;
-  background: var(--color-sensitive-green);
   border: 4px solid var(--color-rich-green);
+  background: var(--color-sensitive-green);
+  min-height: 320px;
 }
 
-.framework-functions__animation::before,
-.framework-functions__animation::after {
+.function-showcase__visual::before,
+.function-showcase__visual::after {
   content: '';
   position: absolute;
   border-radius: 50%;
 }
 
-.framework-functions__animation--orbit::before {
+.function-showcase__visual--orbit {
+  border-color: var(--color-rich-green);
+  background: var(--color-sensitive-green);
+}
+
+.function-showcase__visual--orbit::before {
   inset: 18% 32% 20% 6%;
   border: 4px solid var(--color-vibrant-magenta);
   border-radius: 40px;
   animation: showcaseOrbit 11s infinite linear;
 }
 
-.framework-functions__animation--orbit::after {
+.function-showcase__visual--orbit::after {
   width: 68px;
   height: 68px;
   top: 18%;
@@ -88,21 +168,31 @@
   animation: showcaseFloat 7s infinite ease-in-out;
 }
 
-.framework-functions__animation--pulse::before {
+.function-showcase__visual--pulse {
+  border-color: var(--color-rich-purple);
+  background: var(--color-sensitive-pink);
+}
+
+.function-showcase__visual--pulse::before {
   inset: 18% 20% 18% 20%;
   border-radius: 26px;
   border: 4px solid var(--color-vibrant-green);
   animation: showcasePulse 6s infinite ease-in-out;
 }
 
-.framework-functions__animation--pulse::after {
+.function-showcase__visual--pulse::after {
   inset: 26% 34% 24% 34%;
   border-radius: 18px;
   background: var(--color-vibrant-magenta);
   animation: showcaseOrbit 9s infinite ease-in-out;
 }
 
-.framework-functions__animation--wave::before {
+.function-showcase__visual--wave {
+  border-color: var(--color-rich-blue);
+  background: var(--color-sensitive-blue);
+}
+
+.function-showcase__visual--wave::before {
   inset: 8% -10% 36% -16%;
   background: var(--color-vibrant-cyan);
   border-radius: 28px;
@@ -110,7 +200,7 @@
   animation: showcaseDrift 12s infinite ease-in-out;
 }
 
-.framework-functions__animation--wave::after {
+.function-showcase__visual--wave::after {
   width: 56px;
   height: 56px;
   bottom: 14%;
@@ -118,26 +208,6 @@
   background: var(--color-rich-blue);
   border-radius: 18px;
   animation: showcaseFloat 9s infinite ease-in-out;
-}
-
-.framework-functions__name {
-  font-size: 1.4rem;
-  font-weight: 700;
-  color: var(--color-rich-purple);
-}
-
-.framework-functions__description {
-  color: var(--text);
-  line-height: 1.7;
-}
-
-.framework-functions__meta {
-  margin-top: auto;
-  display: flex;
-  align-items: center;
-  gap: 0.65rem;
-  color: var(--muted);
-  font-size: 0.85rem;
 }
 
 @keyframes showcaseOrbit {
@@ -180,8 +250,18 @@
 }
 
 @media (max-width: 1024px) {
-  .framework-functions__grid {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
+  .function-showcase {
+    padding: 2rem;
+  }
+
+  .function-showcase__layout {
+    flex-direction: column;
+  }
+
+  .function-showcase__visual {
+    max-width: none;
+    width: 100%;
+    min-height: 260px;
   }
 }
 
@@ -190,7 +270,16 @@
     padding: 3.5rem 0 1.5rem;
   }
 
-  .framework-functions__grid {
-    grid-template-columns: 1fr;
+  .function-showcase {
+    padding: 1.75rem;
+  }
+
+  .function-showcase__focus-item {
+    padding-left: 1rem;
+  }
+
+  .function-showcase__focus-item::before {
+    top: 0.2rem;
+    bottom: 0.2rem;
   }
 }


### PR DESCRIPTION
## Summary
- replace the homepage function grid with scroll-triggered panels that pair text on the left and animated artwork on the right
- expand the framework function data with richer about copy and focus area details for CMO G&O, GPDS, and GPM
- refresh the function showcase styles to support the new layout, responsive stacking, and motion visuals

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ca98dd79e4832d98381cb9aaa35799