### PR TITLE
Restyle career explorer for wide brand layout

### DIFF
--- a/src/components/JobSkillsMatcher.jsx
+++ b/src/components/JobSkillsMatcher.jsx
@@ -126,10 +126,10 @@ const JobSkillsMatcher = () => {
   );
 
   return (
-    <div className="page solid-bg experience-page">
+    <div className="page solid-bg experience-page experience-page--explorer">
       <SiteHeader />
 
-      <div className="container content experience-content">
+      <div className="container content experience-content experience-content--wide">
         <section className="experience-hero experience-hero--explorer" data-animate="fade-slide">
           <div className="experience-hero__header">
             <div className="experience-hero__icon" aria-hidden="true">
@@ -185,43 +185,43 @@ const JobSkillsMatcher = () => {
           </div>
         </section>
 
-        <section id="career-explorer-filters" className="explorer-panel" data-animate="fade-up">
-          <div className="explorer-panel__header">
+        <section id="career-explorer-filters" className="explorer-toolbar" data-animate="fade-up">
+          <div className="explorer-toolbar__header">
             <div>
               <h2 className="section-h2">Browse positions</h2>
-              <p className="muted text-sm">
+              <p className="explorer-toolbar__subtext">
                 Use search and filters to surface roles across the SPH framework. Open a card to view its skill DNA.
               </p>
             </div>
-            {myPosition && <span className="chip chip--outline">Benchmarking vs {myPosition.title}</span>}
+            {myPosition && <span className="chip chip--outline chip--inverse">Benchmarking vs {myPosition.title}</span>}
           </div>
-          <div className="explorer-filter-grid">
-            <div className="field field--elevated">
-              <label className="field__label" htmlFor="explorer-search">
+          <div className="explorer-toolbar__controls">
+            <div className="toolbar-control">
+              <label className="toolbar-control__label" htmlFor="explorer-search">
                 Search positions
               </label>
-              <div className="field__control">
-                <Search className="icon-sm field__icon" />
+              <div className="toolbar-control__field">
+                <Search className="toolbar-control__icon" />
                 <input
                   id="explorer-search"
                   type="text"
-                  placeholder="Search by title or division..."
-                  className="input input--elevated"
+                  placeholder="Search by title or division"
+                  className="toolbar-control__input"
                   value={searchTerm}
                   onChange={(e) => setSearchTerm(e.target.value)}
                   aria-label="Search jobs"
                 />
               </div>
             </div>
-            <div className="field field--elevated">
-              <label className="field__label" htmlFor="explorer-division">
+            <div className="toolbar-control">
+              <label className="toolbar-control__label" htmlFor="explorer-division">
                 Division filter
               </label>
-              <div className="field__control">
-                <Filter className="icon-sm field__icon" />
+              <div className="toolbar-control__field toolbar-control__field--select">
+                <Filter className="toolbar-control__icon" />
                 <select
                   id="explorer-division"
-                  className="input input--elevated"
+                  className="toolbar-control__input toolbar-control__input--select"
                   value={selectedDivision}
                   onChange={(e) => setSelectedDivision(e.target.value)}
                   aria-label="Filter by division"

--- a/src/styles/layouts/job-skills-matcher.css
+++ b/src/styles/layouts/job-skills-matcher.css
@@ -95,6 +95,18 @@
   }
 }
 
+.experience-page--explorer .container {
+  width: 100%;
+  max-width: none;
+  margin: 0 auto;
+  padding-left: clamp(1.5rem, 5vw, 4rem);
+  padding-right: clamp(1.5rem, 5vw, 4rem);
+}
+
+.experience-content--wide {
+  width: 100%;
+}
+
 .experience-hero {
   position: relative;
   padding: 2.75rem 2.5rem;
@@ -175,6 +187,77 @@
   grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
   position: relative;
   z-index: 1;
+}
+
+.experience-page--explorer .experience-hero {
+  border: none;
+  background: var(--color-rich-purple);
+  box-shadow: 0 32px 72px rgba(16, 11, 48, 0.45);
+}
+
+.experience-page--explorer .experience-hero::before,
+.experience-page--explorer .experience-hero::after {
+  display: none;
+}
+
+.experience-page--explorer .experience-hero__icon {
+  background: var(--color-rich-blue);
+  box-shadow: none;
+}
+
+.experience-page--explorer .experience-hero__subtitle {
+  color: var(--color-neutral-white);
+  opacity: 0.9;
+}
+
+.experience-page--explorer .experience-hero__status-card {
+  background: var(--color-rich-blue);
+  border: 3px solid var(--color-neutral-white);
+  box-shadow: none;
+  color: var(--color-neutral-white);
+}
+
+.experience-page--explorer .experience-hero__status-label,
+.experience-page--explorer .experience-hero__status-value,
+.experience-page--explorer .experience-hero__status-text {
+  color: var(--color-neutral-white);
+}
+
+.experience-page--explorer .experience-hero__status-text {
+  opacity: 0.85;
+}
+
+.experience-page--explorer .experience-hero__actions {
+  flex-direction: row;
+  flex-wrap: wrap;
+}
+
+.experience-page--explorer .experience-hero__actions .button--inverse {
+  background: var(--color-neutral-white);
+  color: var(--color-rich-purple);
+  border-color: transparent;
+}
+
+.experience-page--explorer .experience-hero__actions .button--ghost {
+  border-color: var(--color-neutral-white);
+  color: var(--color-neutral-white);
+}
+
+.experience-page--explorer .chip-link {
+  background: var(--color-rich-purple);
+  border: 1px solid var(--color-neutral-white);
+  color: var(--color-neutral-white);
+}
+
+.experience-page--explorer .chip-link:hover {
+  transform: translateY(-2px);
+  box-shadow: none;
+}
+
+.chip--inverse {
+  background: var(--color-neutral-white);
+  color: var(--color-rich-purple);
+  border-color: transparent;
 }
 
 .experience-hero__status-card {
@@ -263,59 +346,118 @@
   box-shadow: 0 14px 30px rgba(0, 0, 0, 0.16);
 }
 
-.explorer-panel {
-  margin-top: 2.5rem;
-  padding: 2rem;
-  border-radius: 24px;
-  background: var(--surface);
-  border: 2px solid var(--color-border-soft);
-  box-shadow: 0 18px 40px rgba(9, 22, 50, 0.12);
+.explorer-toolbar {
+  margin-top: 3rem;
+  padding: clamp(1.8rem, 3vw, 2.5rem);
+  border-radius: 32px;
+  background: var(--color-rich-blue);
+  color: var(--color-neutral-white);
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+  box-shadow: 0 28px 60px rgba(13, 27, 66, 0.28);
 }
 
-.explorer-panel__header {
+.explorer-toolbar__header {
   display: flex;
   justify-content: space-between;
   gap: 1.5rem;
   align-items: flex-start;
-  margin-bottom: 1.5rem;
 }
 
-.explorer-filter-grid {
-  display: grid;
-  gap: 1.25rem;
-  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+.explorer-toolbar__subtext {
+  margin: 0.5rem 0 0;
+  font-size: 0.95rem;
+  color: var(--color-neutral-white);
+  opacity: 0.85;
 }
 
-.field--elevated .field__control {
-  position: relative;
+.explorer-toolbar__controls {
   display: flex;
-  align-items: center;
+  flex-wrap: wrap;
+  gap: 1.5rem;
 }
 
-.field__label {
-  font-size: 0.8rem;
-  font-weight: 600;
+.toolbar-control {
+  flex: 1 1 280px;
+  background: var(--color-neutral-white);
+  border-radius: 28px;
+  padding: 1.25rem 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  box-shadow: 0 24px 45px rgba(16, 26, 70, 0.2);
+}
+
+.toolbar-control__label {
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
   color: var(--color-rich-purple);
 }
 
-.field__icon {
-  position: absolute;
-  left: 14px;
-  color: var(--muted);
-}
-
-.input--elevated {
-  padding-left: 46px;
-  background: linear-gradient(145deg, rgba(255, 255, 255, 0.92), rgba(244, 243, 255, 0.92));
-  border-radius: 16px;
-  border: 2px solid var(--color-border-soft);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.8);
+.toolbar-control__field {
+  display: flex;
+  align-items: center;
+  gap: 0.9rem;
+  border-radius: 18px;
+  border: 2px solid var(--color-rich-purple);
+  padding: 0.65rem 0.85rem;
   transition: border-color 0.2s ease, box-shadow 0.2s ease;
 }
 
-.input--elevated:focus {
-  border-color: var(--color-rich-purple);
-  box-shadow: 0 0 0 3px rgba(141, 69, 255, 0.25);
+.toolbar-control__field:focus-within {
+  border-color: var(--color-rich-blue);
+  box-shadow: 0 0 0 2px var(--color-rich-blue);
+}
+
+.toolbar-control__icon {
+  color: var(--color-rich-purple);
+}
+
+.toolbar-control__input {
+  flex: 1;
+  border: none;
+  background: transparent;
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--color-neutral-ink);
+  padding: 0;
+}
+
+.toolbar-control__input:focus {
+  outline: none;
+}
+
+.toolbar-control__input::placeholder {
+  color: var(--color-muted);
+  font-weight: 500;
+}
+
+.toolbar-control__field--select {
+  position: relative;
+}
+
+.toolbar-control__field--select::after {
+  content: '';
+  position: absolute;
+  right: 1rem;
+  top: 50%;
+  transform: translateY(-50%);
+  border-left: 6px solid transparent;
+  border-right: 6px solid transparent;
+  border-top: 8px solid var(--color-rich-purple);
+  pointer-events: none;
+}
+
+.toolbar-control__input--select {
+  appearance: none;
+  cursor: pointer;
+}
+
+.toolbar-control__input--select option {
+  color: var(--color-neutral-ink);
 }
 
 .explorer-results-shell {
@@ -328,7 +470,7 @@
 }
 
 .explorer-layout--split {
-  grid-template-columns: minmax(0, 2fr) minmax(280px, 1fr);
+  grid-template-columns: minmax(0, 3fr) minmax(320px, 2fr);
 }
 
 .explorer-results {
@@ -338,11 +480,11 @@
 }
 
 .explorer-group {
-  padding: 1.75rem;
-  border-radius: 24px;
-  background: var(--surface);
-  border: 2px solid var(--color-border-soft);
-  box-shadow: 0 12px 34px rgba(15, 18, 54, 0.1);
+  padding: 2rem;
+  border-radius: 28px;
+  background: var(--color-neutral-white);
+  border: 3px solid var(--color-rich-purple);
+  box-shadow: 0 28px 55px rgba(18, 26, 80, 0.22);
 }
 
 .explorer-group__header {
@@ -362,39 +504,29 @@
 
 .explorer-group__count {
   font-size: 0.85rem;
-  color: var(--muted);
+  color: var(--color-rich-blue);
+  font-weight: 600;
 }
 
 .explorer-card-grid {
   display: grid;
-  gap: 1.2rem;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
 }
 
 .explorer-card {
   position: relative;
   border-radius: 22px;
-  padding: 1rem 1.2rem 1.15rem;
-  background: var(--surface-2);
-  border: 2px solid transparent;
+  padding: 1.25rem 1.4rem 1.35rem;
+  background: var(--color-neutral-white);
+  border: 3px solid var(--color-rich-purple);
   text-align: left;
   cursor: pointer;
   display: flex;
   flex-direction: column;
-  gap: 0.35rem;
-  transition: transform 0.25s ease, box-shadow 0.25s ease, border-color 0.25s ease,
-    background 0.3s ease;
-  box-shadow: 0 12px 28px rgba(21, 12, 74, 0.12);
-}
-
-.explorer-card::before {
-  content: '';
-  position: absolute;
-  inset: 0;
-  border-radius: 20px;
-  background: rgba(255, 255, 255, 0.3);
-  opacity: 0;
-  transition: opacity 0.25s ease;
+  gap: 0.5rem;
+  transition: transform 0.25s ease, box-shadow 0.25s ease, border-color 0.25s ease;
+  box-shadow: 0 24px 50px rgba(14, 18, 68, 0.18);
 }
 
 .explorer-card__title {
@@ -404,8 +536,8 @@
 }
 
 .explorer-card__meta {
-  font-size: 0.82rem;
-  color: var(--muted);
+  font-size: 0.85rem;
+  color: var(--color-rich-blue);
 }
 
 .explorer-card__badge {
@@ -415,67 +547,62 @@
 
 .explorer-card:hover,
 .explorer-card.is-active {
-  transform: translateY(-4px);
-  box-shadow: 0 20px 42px rgba(18, 21, 64, 0.18);
-}
-
-.explorer-card:hover::before,
-.explorer-card.is-active::before {
-  opacity: 0.18;
+  transform: translateY(-6px);
+  border-color: var(--color-rich-blue);
+  box-shadow: 0 30px 60px rgba(14, 18, 68, 0.24);
 }
 
 .tone-green {
-  border-color: rgba(30, 170, 115, 0.38);
+  border-color: var(--color-rich-green);
 }
 
 .tone-yellow {
-  border-color: rgba(252, 214, 98, 0.48);
+  border-color: var(--color-vibrant-yellow);
 }
 
 .tone-lilac {
-  border-color: rgba(141, 89, 255, 0.45);
+  border-color: var(--color-vibrant-magenta);
 }
 
 .tone-blue {
-  border-color: rgba(83, 182, 255, 0.4);
+  border-color: var(--color-rich-blue);
 }
 
 .tone-red {
-  border-color: rgba(218, 67, 103, 0.45);
+  border-color: var(--color-rich-red);
 }
 
 .tone-neutral {
-  border-color: var(--color-border-soft);
+  border-color: var(--color-rich-purple);
 }
 
 .explorer-empty {
   padding: 3rem 2rem;
-  border-radius: 24px;
-  border: 2px dashed var(--color-border-soft);
-  background: var(--surface);
+  border-radius: 28px;
+  border: 3px dashed var(--color-rich-purple);
+  background: var(--color-neutral-white);
   text-align: center;
-  color: var(--muted);
+  color: var(--color-rich-purple);
   display: grid;
   place-items: center;
   gap: 1rem;
 }
 
 .explorer-empty svg {
-  color: var(--color-rich-purple);
-  opacity: 0.3;
+  color: var(--color-rich-blue);
 }
 
 .explorer-empty--inline {
   padding: 1.5rem;
-  border-radius: 18px;
+  border-radius: 20px;
   border-style: dashed;
 }
 
 .explorer-detail {
-  border-radius: 26px;
-  border: 2px solid var(--color-border-soft);
-  background: linear-gradient(145deg, rgba(255, 255, 255, 0.98), rgba(243, 242, 255, 0.98));
-  box-shadow: 0 28px 52px rgba(12, 16, 50, 0.22);
+  border-radius: 30px;
+  border: 3px solid var(--color-rich-purple);
+  background: var(--color-neutral-white);
+  box-shadow: 0 32px 65px rgba(12, 16, 50, 0.28);
   position: sticky;
   top: 2rem;
   align-self: start;
@@ -488,19 +615,19 @@
   display: flex;
   align-items: flex-start;
   gap: 1rem;
-  padding: 1.5rem 1.5rem 1.25rem;
-  border-bottom: 1px solid rgba(28, 20, 60, 0.1);
+  padding: 1.75rem 1.75rem 1.25rem;
+  border-bottom: 2px solid var(--color-rich-purple);
 }
 
 .explorer-detail__icon {
   width: 48px;
   height: 48px;
   border-radius: 16px;
-  background: var(--color-sensitive-blue);
+  background: var(--color-rich-purple);
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  color: var(--color-rich-purple);
+  color: var(--color-neutral-white);
 }
 
 .explorer-detail__title {
@@ -515,13 +642,13 @@
   align-items: center;
   gap: 0.35rem;
   margin: 0.35rem 0 0;
-  color: var(--muted);
-  font-size: 0.9rem;
+  color: var(--color-rich-blue);
+  font-size: 0.92rem;
 }
 
 .explorer-detail__body {
   overflow-y: auto;
-  padding: 1.5rem;
+  padding: 1.75rem;
   display: flex;
   flex-direction: column;
   gap: 1.75rem;
@@ -584,13 +711,14 @@
 }
 
 .explorer-similar {
-  border-radius: 20px;
-  border: 2px solid rgba(110, 94, 208, 0.2);
-  background: rgba(255, 255, 255, 0.86);
-  padding: 1.1rem 1.25rem;
+  border-radius: 22px;
+  border: 3px solid var(--color-rich-purple);
+  background: var(--color-neutral-white);
+  padding: 1.25rem 1.5rem;
   display: flex;
   flex-direction: column;
   gap: 0.65rem;
+  box-shadow: 0 20px 45px rgba(12, 20, 60, 0.18);
 }
 
 .explorer-similar__header {
@@ -601,8 +729,8 @@
 }
 
 .explorer-similar__meta {
-  font-size: 0.82rem;
-  color: var(--muted);
+  font-size: 0.85rem;
+  color: var(--color-rich-blue);
 }
 
 .explorer-similar__summary {
@@ -613,19 +741,23 @@
 }
 
 .explorer-similar.tone-green {
-  border-color: rgba(32, 160, 110, 0.45);
+  border-color: var(--color-rich-green);
 }
 
 .explorer-similar.tone-yellow {
-  border-color: rgba(248, 204, 90, 0.5);
+  border-color: var(--color-vibrant-yellow);
 }
 
 .explorer-similar.tone-lilac {
-  border-color: rgba(141, 89, 255, 0.48);
+  border-color: var(--color-vibrant-magenta);
 }
 
 .explorer-similar.tone-blue {
-  border-color: rgba(83, 182, 255, 0.45);
+  border-color: var(--color-rich-blue);
+}
+
+.explorer-similar.tone-red {
+  border-color: var(--color-rich-red);
 }
 
 .roadmap-panel {
@@ -930,6 +1062,15 @@
     flex-wrap: wrap;
   }
 
+  .experience-page--explorer .container {
+    padding-left: 1.5rem;
+    padding-right: 1.5rem;
+  }
+
+  .explorer-toolbar {
+    padding: 1.75rem;
+  }
+
   .explorer-layout--split {
     grid-template-columns: 1fr;
   }
@@ -941,7 +1082,7 @@
 }
 
 @media (max-width: 640px) {
-  .explorer-panel,
+  .explorer-toolbar,
   .explorer-group {
     padding: 1.5rem;
   }
@@ -950,8 +1091,20 @@
     grid-template-columns: 1fr;
   }
 
+  .toolbar-control {
+    flex: 1 1 100%;
+  }
+
   .roadmap-insights__divider {
     display: none;
+  }
+}
+
+@media (max-width: 540px) {
+  .explorer-toolbar__header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 1rem;
   }
 }
 


### PR DESCRIPTION
## Summary
- expand the Career Explorer page layout to fill the viewport and add an explorer-specific wrapper
- replace the form-like filter panel with a wide brand toolbar and refresh the cards/detail styling to use solid brand colours

## Testing
- npm test -- --watchAll=false --passWithNoTests

------
https://chatgpt.com/codex/tasks/task_e_68caa567c448832d8fc02d9dcd4ff053