### PR TITLE
Align Career Explorer hero with roadmap styling

### DIFF
--- a/src/components/CareerRoadmap.jsx
+++ b/src/components/CareerRoadmap.jsx
@@ -356,10 +356,10 @@ export default function CareerRoadmap() {
   );
 
   return (
-    <div className="page solid-bg experience-page">
+    <div className="page solid-bg experience-page experience-page--roadmap">
       <SiteHeader />
 
-      <div className="container content experience-content">
+      <div className="content experience-content experience-content--wide">
         <section className="experience-hero experience-hero--explorer" data-animate="fade-slide">
           <div className="experience-hero__header">
             <div className="experience-hero__icon" aria-hidden="true">

--- a/src/components/JobSkillsMatcher.jsx
+++ b/src/components/JobSkillsMatcher.jsx
@@ -9,6 +9,7 @@ import {
   TrendingUp,
   MapPin,
   Briefcase,
+  Compass,
 } from 'lucide-react';
 import '../styles/main.css';
 import useJobDataset from '../hooks/useJobDataset';
@@ -19,7 +20,6 @@ import {
   getSimilarityBadge,
 } from '../utils/jobDataUtils';
 import SiteHeader from './SiteHeader';
-import HeroSection from './HeroSection';
 import useRevealOnScroll from '../hooks/useRevealOnScroll';
 
 function getSimilarityTone(sim) {
@@ -133,43 +133,63 @@ const JobSkillsMatcher = () => {
   };
 
   return (
-    <div className="page solid-bg explorer-page">
+    <div className="page solid-bg experience-page experience-page--explorer explorer-page">
       <SiteHeader />
 
-      <HeroSection
-        eyebrow="Career Explorer"
-        title="Discover your next SPH role"
-        description="Search the SPH Career Framework, compare role skill DNA, and shortlist your next moves."
-        primaryCta={{ label: 'Open roadmap planner', to: '/roadmap', variant: 'primary' }}
-        secondaryCta={{ label: 'Browse roles', onClick: handleBrowseRoles, variant: 'ghost' }}
-      >
-        <div className="explorer-hero__status">
-          {myPosition ? (
-            <>
-              <span className="explorer-hero__status-label">Saved starting role</span>
-              <span className="explorer-hero__status-value">{myPosition.title}</span>
-              <Link to="/roadmap" state={roadmapLinkState} className="explorer-hero__status-link">
-                Manage in roadmap
-              </Link>
-            </>
-          ) : (
-            <>
-              <span className="explorer-hero__status-label">Personalise your view</span>
-              <p className="explorer-hero__status-text">
-                Save your current role in the roadmap planner to unlock tailored comparisons here.
-
+      <div className="content experience-content experience-content--wide">
+        <section className="experience-hero experience-hero--explorer" data-animate="fade-slide">
+          <div className="experience-hero__header">
+            <div className="experience-hero__icon" aria-hidden="true">
+              <Compass className="icon-lg" />
+            </div>
+            <div>
+              <h1 className="experience-hero__title">Discover your next SPH role</h1>
+              <p className="experience-hero__subtitle">
+                Search the SPH Career Framework, compare role skill DNA, and shortlist your next moves.
               </p>
-              <Link to="/roadmap" className="explorer-hero__status-link">
-                Go to roadmap planner
+            </div>
+          </div>
+          <div className="experience-hero__grid">
+            <div className="experience-hero__status-card explorer-hero__status">
+              {myPosition ? (
+                <>
+                  <span className="experience-hero__status-label explorer-hero__status-label">Saved starting role</span>
+                  <span className="experience-hero__status-value explorer-hero__status-value">{myPosition.title}</span>
+                  <Link
+                    to="/roadmap"
+                    state={roadmapLinkState}
+                    className="chip chip--inverse explorer-hero__status-link"
+                  >
+                    Manage in roadmap
+                  </Link>
+                </>
+              ) : (
+                <>
+                  <span className="experience-hero__status-label explorer-hero__status-label">
+                    Personalise your view
+                  </span>
+                  <p className="experience-hero__status-text explorer-hero__status-text">
+                    Save your current role in the roadmap planner to unlock tailored comparisons here.
+                  </p>
+                  <Link to="/roadmap" className="chip-link explorer-hero__status-link">
+                    Go to roadmap planner
+                  </Link>
+                </>
+              )}
+            </div>
+            <div className="experience-hero__actions">
+              <Link to="/roadmap" className="button button--inverse">
+                Open roadmap planner
               </Link>
-            </>
-          )}
-        </div>
-      </HeroSection>
+              <button type="button" className="button button--ghost" onClick={handleBrowseRoles}>
+                Browse roles
+              </button>
+            </div>
+          </div>
+        </section>
 
-      <main className="explorer">
-        <section ref={filtersRef} id="career-explorer-filters" className="explorer__filters">
-          <div className="container">
+        <main className="explorer">
+          <section ref={filtersRef} id="career-explorer-filters" className="explorer__filters">
             <div className="explorer-panel" data-animate="fade-up">
               <div className="explorer-panel__header">
                 <div>
@@ -226,11 +246,9 @@ const JobSkillsMatcher = () => {
 
               </div>
             </div>
-          </div>
-        </section>
+          </section>
 
-        <section className="explorer-results-shell">
-          <div className="container">
+          <section className="explorer-results-shell">
             <div className={`explorer-layout ${selectedJob ? 'explorer-layout--split' : ''}`} data-animate="fade-stagger">
               <div className="explorer-results">
                 {Object.keys(groupedJobs).length ? (
@@ -457,9 +475,9 @@ const JobSkillsMatcher = () => {
                 </aside>
               )}
             </div>
-          </div>
-        </section>
-      </main>
+          </section>
+        </main>
+      </div>
     </div>
   );
 

--- a/src/styles/layouts/job-skills-matcher.css
+++ b/src/styles/layouts/job-skills-matcher.css
@@ -104,12 +104,6 @@
 }
 
 .explorer-hero__status {
-  margin-top: 1.75rem;
-  padding: 1.5rem 1.75rem;
-  border-radius: 24px;
-  border: 3px solid var(--color-rich-purple);
-  background: var(--color-neutral-white);
-  color: var(--color-rich-purple);
   display: grid;
   gap: 0.65rem;
   max-width: 420px;
@@ -140,23 +134,12 @@
   align-items: center;
   width: fit-content;
   gap: 0.35rem;
-  padding: 0.4rem 1rem;
-  border-radius: 999px;
-  border: 2px solid var(--color-rich-blue);
-  color: var(--color-rich-blue);
   font-weight: 700;
   text-transform: uppercase;
   font-size: 0.75rem;
   letter-spacing: 0.08em;
   text-decoration: none;
-  transition: transform 0.2s ease, background 0.2s ease, color 0.2s ease;
-}
-
-.explorer-hero__status-link:hover,
-.explorer-hero__status-link:focus-visible {
-  background: var(--color-rich-blue);
-  color: var(--color-neutral-white);
-  transform: translateY(-2px);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease, color 0.2s ease;
 }
 
 .explorer {
@@ -320,6 +303,19 @@
 
 .experience-content--wide {
   width: 100%;
+  max-width: none;
+  margin: 0 auto;
+  padding-left: clamp(1.5rem, 5vw, 4rem);
+  padding-right: clamp(1.5rem, 5vw, 4rem);
+}
+
+.experience-page--explorer {
+  background: var(--color-neutral-white);
+}
+
+.experience-page--explorer::before,
+.experience-page--explorer::after {
+  display: none;
 }
 
 .experience-hero {


### PR DESCRIPTION
## Summary
- replace the Career Explorer landing section with the shared roadmap-style hero while keeping saved-role messaging and actions intact
- stretch both the explorer and roadmap views to the full page width via the new `experience-content--wide` layout wrapper
- tune explorer-specific hero styles so status pills and background treatments match the dark roadmap hero while keeping existing recommendations and planner links

## Testing
- npm test -- --watchAll=false *(fails: no tests defined)*
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cbc4a6b234832dbc56c05b3f31305d