### PR TITLE
Refine recommendations and improve board path visuals

### DIFF
--- a/src/components/CareerRoadmap.jsx
+++ b/src/components/CareerRoadmap.jsx
@@ -121,7 +121,7 @@ const RoadmapDetails = ({ currentJob, targetJob }) => {
                   </div>
                 </div>
                 <div className="roadmap-card__footer">
-                  <span className="roadmap-card__label">Recommended training</span>
+                  <span className="roadmap-card__label">Recommended training from SPH Academy</span>
                   {recs.map((t, idx) => (
                     <div key={idx} className="roadmap-card__training">
                       <BookOpen className="icon-xs" />
@@ -298,6 +298,7 @@ export default function CareerRoadmap() {
 
   const recommendationsForMyPosition = useMemo(() => {
     if (!myPosition) return [];
+    const myRank = myPosition.seniorityRank ?? null;
     return jobs
       .filter((job) => job.id !== myPosition.id)
       .map((job) => ({
@@ -305,6 +306,11 @@ export default function CareerRoadmap() {
         similarity: simScore(myPosition, job),
         summary: summarizeTransition(myPosition, job, 2),
       }))
+      .filter((job) => {
+        if (myRank == null) return true;
+        if (job.seniorityRank == null) return true;
+        return job.seniorityRank >= myRank;
+      })
       .filter((job) => job.similarity >= 60)
       .sort((a, b) => b.similarity - a.similarity)
       .slice(0, 8);

--- a/src/components/JobSkillsMatcher.jsx
+++ b/src/components/JobSkillsMatcher.jsx
@@ -132,6 +132,7 @@ const JobSkillsMatcher = () => {
 
   const recommendationsForMyPosition = useMemo(() => {
     if (!myPosition) return [];
+    const myRank = myPosition.seniorityRank ?? null;
     return jobs
       .filter((job) => job.id !== myPosition.id)
       .map((job) => ({
@@ -139,6 +140,11 @@ const JobSkillsMatcher = () => {
         similarity: simScore(myPosition, job),
         summary: summarizeTransition(myPosition, job, 2),
       }))
+      .filter((job) => {
+        if (myRank == null) return true;
+        if (job.seniorityRank == null) return true;
+        return job.seniorityRank >= myRank;
+      })
       .filter((job) => job.similarity >= 60)
       .sort((a, b) => b.similarity - a.similarity)
       .slice(0, 6);

--- a/src/styles/layouts/career-roadmap.css
+++ b/src/styles/layouts/career-roadmap.css
@@ -663,10 +663,24 @@
   border-radius: 14px;
   background: var(--surface);
   box-shadow: var(--shadow);
+  overflow: visible;
 }
 
 .tile.grid { min-width: auto; max-width: none; width: 100%; }
-.tile.active { border-color: var(--color-rich-purple); box-shadow: 0 6px 16px rgba(0, 0, 0, 0.15); }
+.tile.reached {
+  background: linear-gradient(135deg, rgba(80, 50, 145, 0.12), rgba(45, 190, 205, 0.08));
+  border-color: rgba(80, 50, 145, 0.45);
+  box-shadow: 0 6px 14px rgba(80, 50, 145, 0.15);
+}
+.tile.reached .tile-index {
+  background: var(--color-vibrant-cyan);
+  color: var(--color-text);
+}
+.tile.active {
+  border-color: var(--color-rich-purple);
+  box-shadow: 0 10px 22px rgba(80, 50, 145, 0.28);
+  background: linear-gradient(135deg, rgba(80, 50, 145, 0.18), rgba(165, 205, 80, 0.14));
+}
 .tile-index {
   display: inline-flex;
   align-items: center;
@@ -687,6 +701,66 @@
   background: var(--color-vibrant-green);
   border: 2px solid var(--color-rich-green);
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
+}
+
+.tile-direction {
+  position: absolute;
+  width: 28px;
+  height: 28px;
+  border-radius: 999px;
+  background: var(--color-rich-purple);
+  color: var(--color-text-inverse);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 15px;
+  font-weight: 700;
+  pointer-events: none;
+  opacity: 0;
+  z-index: 2;
+  --x: 0;
+  --y: 0;
+  transform: translate(var(--x), var(--y)) scale(0.8);
+  transition: opacity 0.18s ease, transform 0.18s ease;
+  box-shadow: 0 6px 12px rgba(80, 50, 145, 0.2);
+}
+.tile-direction::before {
+  content: '→';
+  line-height: 1;
+}
+.tile-direction--right {
+  top: 50%;
+  right: -18px;
+  --x: 50%;
+  --y: -50%;
+}
+.tile-direction--left {
+  top: 50%;
+  left: -18px;
+  --x: -50%;
+  --y: -50%;
+}
+.tile-direction--left::before {
+  content: '←';
+}
+.tile-direction--down {
+  bottom: -18px;
+  left: 50%;
+  --x: -50%;
+  --y: 50%;
+}
+.tile-direction--down::before {
+  content: '↓';
+}
+.tile-direction.active {
+  opacity: 1;
+  transform: translate(var(--x), var(--y)) scale(1);
+}
+.tile-direction.pending {
+  opacity: 0.75;
+  background: var(--color-vibrant-green);
+  color: var(--color-text);
+  transform: translate(var(--x), var(--y)) scale(0.95);
 }
 
 .connector { position: absolute; right: -24px; top: 24px; width: 24px; height: 2px; background: var(--color-border-soft); }

--- a/src/utils/jobDataUtils.js
+++ b/src/utils/jobDataUtils.js
@@ -30,6 +30,31 @@ export function classifyType(typeRaw) {
   return 'unknown';
 }
 
+export function inferSeniorityRank(title) {
+  const s = String(title || '').toLowerCase();
+
+  if (/(intern|apprentice|fellow)/.test(s)) return 1;
+  if (/(junior|assistant|trainee)/.test(s)) return 2;
+  if (/(support|coordinator|\bpc\b|administrator)/.test(s)) return 2;
+  if (/(associate|analyst|officer)/.test(s)) return 3;
+
+  if (/(vice president|\bvp\b|\bsvp\b|\bevp\b)/.test(s)) return 8;
+  if (/(head of|^head\b)/.test(s)) return 8;
+  if (/(chief)/.test(s) && !/(manager|director|lead|leader)/.test(s)) return 8;
+
+  if (/(executive director)/.test(s)) return 8;
+  if (/(director|medical director|principal)/.test(s)) {
+    return /senior/.test(s) ? 8 : 7;
+  }
+
+  if (/(senior).*(manager|lead|leader)/.test(s)) return 7;
+  if (/(manager|lead|leader)/.test(s)) return 6;
+  if (/senior/.test(s)) return 5;
+  if (/(specialist|consultant|scientist|advisor|expert)/.test(s)) return 4;
+
+  return 4;
+}
+
 export function parseProficiency(row) {
   const rawValue = getCI(row, 'Proficiency Value');
   const rawLevel = getCI(row, 'Required Proficiency Level');
@@ -163,7 +188,8 @@ export function getTrainingRecommendations(skillName, typeOrGuess, gap) {
   ];
   const pool = /soft/i.test(typeOrGuess) ? soft : functional;
   const count = Math.min(3, Math.max(1, Math.ceil(gap || 1)));
-  return pool.slice(0, count);
+  const prefix = 'SPH Academy • ';
+  return pool.slice(0, count).map((item) => `${prefix}${item}`);
 }
 
 export function transformRowsToJobs(rows) {
@@ -226,6 +252,7 @@ export function transformRowsToJobs(rows) {
       id: id++,
       title: job.title,
       division: job.division || 'Unknown Division',
+      seniorityRank: inferSeniorityRank(job.title),
       skills,
       skillOrder: job.skillOrder,
       skillMap: job.skillMap,


### PR DESCRIPTION
## Summary
- infer seniority ranks for each role and use them to drop recommendations that would be a level below the saved position
- surface SPH Academy as the source of suggested training modules in the roadmap experience
- highlight the board-game path with coloured tiles and directional markers so dice rolls show every step

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68d0630b8a88832d99d49e998bd05ac0