### PR TITLE
Refresh explorer and roadmap styling

### DIFF
--- a/src/styles/components/buttons.css
+++ b/src/styles/components/buttons.css
@@ -10,17 +10,30 @@
   align-items: center;
   justify-content: center;
   gap: 0.5rem;
-  padding: 0.625rem 1rem;
+  padding: 0.65rem 1.1rem;
   border-radius: 14px;
-  border: 2px solid var(--color-border-soft);
+  border: 1px solid rgba(80, 50, 145, 0.22);
   cursor: pointer;
   font-weight: 700;
   font-size: 0.9375rem;
   letter-spacing: 0.01em;
-  transition: transform 0.15s ease, box-shadow 0.15s ease,
-  background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
-  background: var(--surface);
-  color: var(--color-text);
+  transition: transform 0.18s ease, box-shadow 0.18s ease,
+    background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+  background: linear-gradient(140deg, rgba(255, 255, 255, 0.95), rgba(241, 237, 255, 0.9));
+  color: var(--color-rich-purple);
+  box-shadow: 0 14px 32px rgba(32, 32, 72, 0.12);
+}
+
+.button:hover,
+.btn:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 22px 50px rgba(32, 32, 72, 0.16);
+}
+
+.button:focus-visible,
+.btn:focus-visible {
+  outline: 3px solid rgba(45, 190, 205, 0.4);
+  outline-offset: 2px;
 }
 
 .button:disabled,
@@ -33,16 +46,17 @@
 
 .button--primary,
 .btn.primary {
-  background: var(--color-rich-purple);
+  background: linear-gradient(135deg, #6a4ae0, #2f9adf);
   color: var(--color-text-inverse);
-  border-color: var(--color-rich-purple);
-  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.24);
+  border-color: transparent;
+  box-shadow: 0 26px 56px rgba(71, 61, 160, 0.45);
 }
 
 .button--primary:hover,
 .btn.primary:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 18px 42px rgba(0, 0, 0, 0.28);
+  transform: translateY(-3px);
+  box-shadow: 0 32px 64px rgba(71, 61, 160, 0.5);
+  filter: brightness(1.05);
 }
 
 .button--primary:focus-visible,
@@ -53,27 +67,30 @@
 
 .button--secondary,
 .btn.secondary {
-  background: var(--color-vibrant-yellow);
+  background: linear-gradient(135deg, #ffe9a9, #ffd46a);
   color: var(--color-rich-purple);
-  border-color: var(--color-rich-purple);
+  border-color: rgba(255, 210, 102, 0.6);
+  box-shadow: 0 18px 40px rgba(205, 168, 70, 0.25);
 }
 
 .button--secondary:hover,
 .btn.secondary:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.18);
+  transform: translateY(-3px);
+  box-shadow: 0 26px 56px rgba(205, 168, 70, 0.3);
 }
 
 .button--ghost,
 .btn.ghost {
-  background: transparent;
+  background: rgba(80, 50, 145, 0.08);
   color: var(--color-rich-purple);
-  border-color: var(--color-rich-purple);
+  border-color: rgba(80, 50, 145, 0.28);
+  box-shadow: 0 10px 26px rgba(80, 50, 145, 0.12);
 }
 
 .button--ghost:hover,
 .btn.ghost:hover {
-  background: var(--color-sensitive-pink);
+  background: rgba(80, 50, 145, 0.14);
+  box-shadow: 0 16px 34px rgba(80, 50, 145, 0.18);
 }
 
 .button--ghost:focus-visible,
@@ -83,15 +100,15 @@
 }
 
 .button--inverse {
-  background: var(--color-text-inverse);
+  background: linear-gradient(140deg, #ffffff, #f2f5ff);
   color: var(--color-rich-purple);
-  border-color: transparent;
-  box-shadow: 0 22px 45px rgba(0, 0, 0, 0.28);
+  border-color: rgba(80, 50, 145, 0.16);
+  box-shadow: 0 28px 60px rgba(20, 32, 70, 0.28);
 }
 
 .button--inverse:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 26px 52px rgba(0, 0, 0, 0.3);
+  transform: translateY(-3px);
+  box-shadow: 0 36px 72px rgba(20, 32, 70, 0.32);
 }
 
 .button--inverse:focus-visible {
@@ -101,17 +118,17 @@
 
 .button--fun,
 .btn.fun {
-  background: var(--color-rich-red);
+  background: linear-gradient(135deg, #ff5aa5, #ff7a5c);
   color: var(--color-text-inverse);
   border: 0;
   padding: 0.65rem 1.25rem;
-  box-shadow: 0 20px 36px rgba(0, 0, 0, 0.25);
+  box-shadow: 0 24px 48px rgba(204, 66, 109, 0.38);
 }
 
 .button--fun:hover,
 .btn.fun:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 24px 48px rgba(0, 0, 0, 0.32);
+  transform: translateY(-3px);
+  box-shadow: 0 32px 64px rgba(204, 66, 109, 0.42);
 }
 
 .button--fun:focus-visible,
@@ -133,46 +150,51 @@
 }
 
 .icon-button {
-  background: var(--color-sensitive-blue);
+  background: rgba(45, 190, 205, 0.16);
   color: var(--color-rich-purple);
-  border: 1px solid var(--color-rich-purple);
+  border: 1px solid rgba(45, 190, 205, 0.36);
   padding: 0.375rem 0.5rem;
   border-radius: 12px;
   cursor: pointer;
-  transition: background 0.2s ease, color 0.2s ease;
+  transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+  box-shadow: 0 10px 24px rgba(28, 116, 130, 0.18);
 }
 
 .icon-button:hover {
-  background: var(--color-sensitive-green);
+  background: rgba(45, 190, 205, 0.24);
+  box-shadow: 0 16px 34px rgba(28, 116, 130, 0.22);
 }
 
 .badge {
   font-size: 0.75rem;
-  padding: 0.25rem 0.75rem;
+  padding: 0.3rem 0.8rem;
   border-radius: 999px;
-  border: 1px solid var(--color-border-soft);
-  font-weight: 700;
+  border: 1px solid rgba(80, 50, 145, 0.24);
+  font-weight: 600;
   display: inline-flex;
   align-items: center;
   gap: 0.4rem;
+  background: rgba(80, 50, 145, 0.08);
+  color: var(--color-rich-purple);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
 }
 
 .badge.green {
-  background: var(--color-sensitive-green);
+  background: rgba(20, 155, 95, 0.14);
   color: var(--color-rich-green);
-  border-color: var(--color-rich-green);
+  border-color: rgba(20, 155, 95, 0.3);
 }
 
 .badge.yellow {
-  background: var(--color-sensitive-yellow);
+  background: rgba(255, 200, 50, 0.18);
   color: var(--color-rich-purple);
-  border-color: var(--color-vibrant-yellow);
+  border-color: rgba(255, 200, 50, 0.4);
 }
 
 .badge.purple {
-  background: var(--color-rich-purple);
+  background: linear-gradient(135deg, #6a4ae0, #4c70f0);
   color: var(--color-text-inverse);
-  border-color: var(--color-rich-purple);
+  border-color: transparent;
 }
 
 .badge.solid {
@@ -180,21 +202,21 @@
 }
 
 .badge.solid.green {
-  background: var(--color-rich-green);
+  background: linear-gradient(135deg, #3bc47b, #16a05d);
   color: var(--color-text-inverse);
 }
 
 .badge.solid.yellow {
-  background: var(--color-vibrant-yellow);
+  background: linear-gradient(135deg, #ffd65d, #ffb71b);
   color: var(--color-rich-purple);
 }
 
 .badge.solid.orange {
-  background: var(--color-vibrant-magenta);
+  background: linear-gradient(135deg, #ff6bb5, #ff508a);
   color: var(--color-text-inverse);
 }
 
 .badge.solid.gray {
-  background: var(--color-sensitive-pink);
+  background: rgba(80, 50, 145, 0.14);
   color: var(--color-rich-purple);
 }

--- a/src/styles/layouts/career-explorer.css
+++ b/src/styles/layouts/career-explorer.css
@@ -185,12 +185,15 @@
 }
 
 .explorer-panel {
-  background: var(--color-neutral-white);
-  border: 3px solid var(--color-rich-purple);
+  position: relative;
+  background: linear-gradient(160deg, rgba(255, 255, 255, 0.96), rgba(232, 241, 255, 0.9));
+  border: 1px solid rgba(80, 50, 145, 0.18);
   border-radius: 32px;
   padding: clamp(1.8rem, 3vw, 2.75rem);
   display: grid;
   gap: 2rem;
+  box-shadow: 0 28px 70px rgba(20, 32, 75, 0.18);
+  overflow: hidden;
 }
 
 .explorer-panel__header {
@@ -207,9 +210,9 @@
   gap: 0.5rem;
   padding: 0.3rem 0.85rem;
   border-radius: 999px;
-  background: var(--color-vibrant-yellow);
+  background: linear-gradient(135deg, rgba(255, 223, 122, 0.95), rgba(255, 191, 94, 0.9));
   color: var(--color-rich-purple);
-  border: 2px solid var(--color-rich-purple);
+  border: 1px solid rgba(255, 191, 94, 0.6);
   text-transform: uppercase;
   font-size: 0.75rem;
   letter-spacing: 0.08em;
@@ -236,12 +239,13 @@
   gap: 0.35rem;
   padding: 0.35rem 0.85rem;
   border-radius: 999px;
-  border: 2px solid var(--color-rich-purple);
+  border: 1px solid rgba(80, 50, 145, 0.3);
   font-size: 0.75rem;
   font-weight: 700;
   letter-spacing: 0.08em;
   text-transform: uppercase;
   color: var(--color-rich-purple);
+  background: rgba(80, 50, 145, 0.08);
 }
 
 .explorer-panel__controls {
@@ -260,7 +264,7 @@
   font-weight: 700;
   letter-spacing: 0.05em;
   text-transform: uppercase;
-  color: var(--color-rich-purple);
+  color: rgba(80, 50, 145, 0.85);
 }
 
 .explorer-control__field {
@@ -269,18 +273,21 @@
   gap: 0.75rem;
   padding: 0.75rem 1rem;
   border-radius: 20px;
-  border: 2px solid var(--color-rich-purple);
-  background: var(--color-neutral-white);
-  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  border: 1px solid rgba(80, 50, 145, 0.22);
+  background: rgba(255, 255, 255, 0.92);
+  box-shadow: 0 16px 34px rgba(30, 41, 80, 0.12);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
 }
 
 .explorer-control__field:focus-within {
-  border-color: var(--color-rich-blue);
-  box-shadow: 0 0 0 2px var(--color-rich-blue);
+  border-color: rgba(45, 190, 205, 0.65);
+  box-shadow: 0 18px 40px rgba(45, 190, 205, 0.25);
+  transform: translateY(-1px);
 }
 
 .explorer-control__icon {
   color: var(--color-rich-purple);
+  opacity: 0.8;
 }
 
 .explorer-control__input {
@@ -343,16 +350,33 @@
 }
 
 .experience-page--explorer {
-  background: var(--color-neutral-white);
+  background: linear-gradient(180deg, #f6f2ff 0%, #f4fbff 55%, #ffffff 100%);
 }
 
 .experience-page--explorer::before,
 .experience-page--explorer::after {
-  display: none;
+  display: block;
+  opacity: 1;
+}
+
+.experience-page--explorer::before {
+  width: 620px;
+  height: 620px;
+  top: -260px;
+  right: -200px;
+  background: radial-gradient(circle at center, rgba(79, 129, 255, 0.28) 0%, rgba(255, 255, 255, 0) 72%);
+}
+
+.experience-page--explorer::after {
+  width: 560px;
+  height: 560px;
+  bottom: -240px;
+  left: -180px;
+  background: radial-gradient(circle at center, rgba(120, 76, 206, 0.24) 0%, rgba(255, 255, 255, 0) 74%);
 }
 
 .experience-hero--explorer {
-  background: linear-gradient(145deg, var(--color-rich-purple), #2d0c50 65%, #401c7a 100%);
+  background: linear-gradient(140deg, #5c3cc7 0%, #2e9bd6 100%);
 }
 
 
@@ -362,9 +386,9 @@
 
 
 .experience-page--explorer .experience-hero {
-  border: 1px solid rgba(255, 255, 255, 0.18);
-  background: linear-gradient(140deg, #17092f 0%, #351263 48%, #5a2b9c 100%);
-  box-shadow: 0 34px 90px rgba(9, 4, 32, 0.55);
+  border: 1px solid rgba(255, 255, 255, 0.35);
+  background: linear-gradient(135deg, rgba(55, 36, 125, 0.95), rgba(41, 126, 190, 0.92));
+  box-shadow: 0 46px 110px rgba(23, 34, 84, 0.5);
   overflow: hidden;
 }
 
@@ -372,41 +396,51 @@
 .experience-page--explorer .experience-hero::after {
   display: block;
   filter: none;
-  opacity: 0.55;
+  opacity: 0.6;
 }
 
 .experience-page--explorer .experience-hero::before {
-  width: 520px;
-  height: 520px;
-  top: -220px;
-  right: -160px;
-  background: radial-gradient(circle at center, rgba(255, 255, 255, 0.45) 0%, rgba(255, 255, 255, 0) 72%);
-  animation-duration: 16s;
+  width: 580px;
+  height: 580px;
+  top: -260px;
+  right: -200px;
+  background: radial-gradient(circle at center, rgba(255, 255, 255, 0.35) 0%, rgba(255, 255, 255, 0) 72%);
+  animation-duration: 18s;
 }
 
 .experience-page--explorer .experience-hero::after {
-  width: 560px;
-  height: 560px;
-  bottom: -280px;
-  left: -200px;
-  background: radial-gradient(circle at center, rgba(118, 197, 255, 0.48) 0%, rgba(255, 255, 255, 0) 74%);
-  animation-delay: 0.6s;
+  width: 540px;
+  height: 540px;
+  bottom: -260px;
+  left: -160px;
+  background: radial-gradient(circle at center, rgba(76, 205, 255, 0.4) 0%, rgba(255, 255, 255, 0) 74%);
+  animation-delay: 0.8s;
 }
 
 .experience-page--explorer .experience-hero__icon {
-  background: rgba(255, 255, 255, 0.18);
-  box-shadow: 0 18px 44px rgba(8, 3, 26, 0.42);
+  background: rgba(255, 255, 255, 0.22);
+  box-shadow: 0 22px 50px rgba(16, 24, 58, 0.45);
 }
 
 .experience-page--explorer .experience-hero__subtitle {
-  color: rgba(255, 255, 255, 0.9);
+  color: rgba(236, 241, 255, 0.9);
 }
 
 .experience-page--explorer .experience-hero__status-card {
-  background: rgba(10, 4, 35, 0.55);
-  border: 1px solid rgba(255, 255, 255, 0.24);
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
+  background: linear-gradient(160deg, rgba(255, 255, 255, 0.14), rgba(17, 70, 170, 0.22));
+  border: 1px solid rgba(173, 203, 255, 0.45);
+  box-shadow: 0 24px 54px rgba(10, 22, 58, 0.45);
   color: var(--color-neutral-white);
+  backdrop-filter: blur(16px);
+}
+
+.experience-page--explorer .experience-hero__status-card .experience-hero__status-value {
+  color: #ffeaa3;
+}
+
+.experience-page--explorer .experience-hero__status-card .experience-hero__status-label,
+.experience-page--explorer .experience-hero__status-card .experience-hero__status-text {
+  color: rgba(236, 241, 255, 0.78);
 }
 
 .experience-page--explorer .experience-hero__actions {
@@ -415,25 +449,31 @@
 }
 
 .experience-page--explorer .experience-hero__actions .button--inverse {
-  background: var(--color-neutral-white);
+  background: linear-gradient(135deg, #ffffff, #e9f3ff);
   color: var(--color-rich-purple);
-  border-color: transparent;
+  border-color: rgba(255, 255, 255, 0.4);
 }
 
 .experience-page--explorer .experience-hero__actions .button--ghost {
-  border-color: var(--color-neutral-white);
+  background: rgba(255, 255, 255, 0.16);
+  border-color: rgba(255, 255, 255, 0.35);
   color: var(--color-neutral-white);
 }
 
+.experience-page--explorer .experience-hero__actions .button--ghost:hover {
+  background: rgba(255, 255, 255, 0.26);
+}
+
 .experience-page--explorer .chip-link {
-  background: var(--color-rich-purple);
-  border: 1px solid var(--color-neutral-white);
+  background: rgba(255, 255, 255, 0.18);
+  border: 1px solid rgba(255, 255, 255, 0.32);
   color: var(--color-neutral-white);
 }
 
 .experience-page--explorer .chip-link:hover {
   transform: translateY(-2px);
   box-shadow: none;
+  color: var(--color-neutral-white);
 }
 
 
@@ -441,12 +481,12 @@
   margin-top: 3rem;
   padding: clamp(1.8rem, 3vw, 2.5rem);
   border-radius: 32px;
-  background: var(--color-rich-blue);
+  background: linear-gradient(155deg, rgba(72, 120, 214, 0.95), rgba(96, 64, 204, 0.92));
   color: var(--color-neutral-white);
   display: flex;
   flex-direction: column;
   gap: 2rem;
-  box-shadow: 0 28px 60px rgba(13, 27, 66, 0.28);
+  box-shadow: 0 34px 80px rgba(18, 32, 72, 0.32);
 }
 
 .explorer-toolbar__header {
@@ -471,13 +511,13 @@
 
 .toolbar-control {
   flex: 1 1 280px;
-  background: var(--color-neutral-white);
+  background: rgba(255, 255, 255, 0.95);
   border-radius: 28px;
   padding: 1.25rem 1.5rem;
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
-  box-shadow: 0 24px 45px rgba(16, 26, 70, 0.2);
+  box-shadow: 0 26px 60px rgba(12, 22, 60, 0.24);
 }
 
 .toolbar-control__label {
@@ -493,18 +533,22 @@
   align-items: center;
   gap: 0.9rem;
   border-radius: 18px;
-  border: 2px solid var(--color-rich-purple);
+  border: 1px solid rgba(80, 50, 145, 0.22);
   padding: 0.65rem 0.85rem;
-  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  background: rgba(255, 255, 255, 0.92);
+  box-shadow: 0 14px 30px rgba(24, 32, 72, 0.14);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
 }
 
 .toolbar-control__field:focus-within {
-  border-color: var(--color-rich-blue);
-  box-shadow: 0 0 0 2px var(--color-rich-blue);
+  border-color: rgba(45, 190, 205, 0.65);
+  box-shadow: 0 18px 40px rgba(45, 190, 205, 0.25);
+  transform: translateY(-1px);
 }
 
 .toolbar-control__icon {
   color: var(--color-rich-purple);
+  opacity: 0.8;
 }
 
 .toolbar-control__input {
@@ -755,14 +799,37 @@
 }
 
 .explorer-similar {
+  position: relative;
   border-radius: 22px;
-  border: 3px solid var(--color-rich-purple);
-  background: var(--color-neutral-white);
-  padding: 1.25rem 1.5rem;
+  border: 1px solid rgba(80, 50, 145, 0.18);
+  background: linear-gradient(145deg, rgba(255, 255, 255, 0.96), rgba(235, 240, 255, 0.92));
+  padding: 1.35rem 1.6rem;
   display: flex;
   flex-direction: column;
   gap: 0.65rem;
-  box-shadow: 0 20px 45px rgba(12, 20, 60, 0.18);
+  box-shadow: 0 26px 60px rgba(18, 32, 72, 0.18);
+  overflow: hidden;
+}
+
+.explorer-similar::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: linear-gradient(135deg, rgba(92, 60, 199, 0.08), rgba(46, 155, 214, 0.06));
+  opacity: 0;
+  transition: opacity 0.2s ease;
+  pointer-events: none;
+  z-index: 0;
+}
+
+.explorer-similar:hover::before {
+  opacity: 1;
+}
+
+.explorer-similar > * {
+  position: relative;
+  z-index: 1;
 }
 
 .explorer-similar__header {
@@ -785,23 +852,28 @@
 }
 
 .explorer-similar.tone-green {
-  border-color: var(--color-rich-green);
+  border-color: rgba(20, 155, 95, 0.32);
+  box-shadow: 0 28px 60px rgba(20, 155, 95, 0.18);
 }
 
 .explorer-similar.tone-yellow {
-  border-color: var(--color-vibrant-yellow);
+  border-color: rgba(255, 200, 50, 0.32);
+  box-shadow: 0 28px 60px rgba(255, 200, 50, 0.2);
 }
 
 .explorer-similar.tone-lilac {
-  border-color: var(--color-vibrant-magenta);
+  border-color: rgba(235, 60, 150, 0.28);
+  box-shadow: 0 28px 60px rgba(166, 76, 206, 0.18);
 }
 
 .explorer-similar.tone-blue {
-  border-color: var(--color-rich-blue);
+  border-color: rgba(47, 138, 220, 0.32);
+  box-shadow: 0 28px 60px rgba(47, 138, 220, 0.2);
 }
 
 .explorer-similar.tone-red {
-  border-color: var(--color-rich-red);
+  border-color: rgba(230, 30, 80, 0.3);
+  box-shadow: 0 28px 60px rgba(230, 30, 80, 0.18);
 }
 
 .explorer-recommendations {
@@ -832,14 +904,37 @@
 }
 
 .explorer-recommendation {
+  position: relative;
   border-radius: 22px;
-  border: 2px solid rgba(120, 112, 210, 0.2);
-  background: linear-gradient(160deg, rgba(255, 255, 255, 0.97), rgba(238, 235, 255, 0.92));
+  border: 1px solid rgba(80, 50, 145, 0.2);
+  background: linear-gradient(155deg, rgba(255, 255, 255, 0.96), rgba(235, 243, 255, 0.92));
   padding: 1.35rem 1.5rem;
-  box-shadow: 0 18px 42px rgba(18, 20, 65, 0.16);
+  box-shadow: 0 28px 64px rgba(20, 32, 75, 0.2);
   display: flex;
   flex-direction: column;
   gap: 0.9rem;
+  overflow: hidden;
+}
+
+.explorer-recommendation::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: linear-gradient(140deg, rgba(92, 60, 199, 0.08), rgba(46, 155, 214, 0.06));
+  opacity: 0;
+  transition: opacity 0.2s ease;
+  pointer-events: none;
+  z-index: 0;
+}
+
+.explorer-recommendation:hover::before {
+  opacity: 1;
+}
+
+.explorer-recommendation > * {
+  position: relative;
+  z-index: 1;
 }
 
 .explorer-recommendation__header {
@@ -873,23 +968,28 @@
 }
 
 .explorer-recommendation.tone-green {
-  border-color: var(--color-rich-green);
+  border-color: rgba(20, 155, 95, 0.35);
+  box-shadow: 0 30px 64px rgba(20, 155, 95, 0.2);
 }
 
 .explorer-recommendation.tone-yellow {
-  border-color: var(--color-vibrant-yellow);
+  border-color: rgba(255, 200, 50, 0.35);
+  box-shadow: 0 30px 64px rgba(255, 200, 50, 0.22);
 }
 
 .explorer-recommendation.tone-lilac {
-  border-color: var(--color-vibrant-magenta);
+  border-color: rgba(235, 60, 150, 0.3);
+  box-shadow: 0 30px 64px rgba(166, 76, 206, 0.2);
 }
 
 .explorer-recommendation.tone-blue {
-  border-color: var(--color-rich-blue);
+  border-color: rgba(47, 138, 220, 0.35);
+  box-shadow: 0 30px 64px rgba(47, 138, 220, 0.22);
 }
 
 .explorer-recommendation.tone-red {
-  border-color: var(--color-rich-red);
+  border-color: rgba(230, 30, 80, 0.35);
+  box-shadow: 0 30px 64px rgba(230, 30, 80, 0.2);
 }
 
 @media (max-width: 960px) {

--- a/src/styles/layouts/career-roadmap.css
+++ b/src/styles/layouts/career-roadmap.css
@@ -1,12 +1,61 @@
 /* SPH Career Roadmap layout styles */
 
+.experience-page--roadmap {
+  background: linear-gradient(180deg, #f5f2ff 0%, #f2fbff 60%, #ffffff 100%);
+}
+
+.experience-page--roadmap::before,
+.experience-page--roadmap::after {
+  display: block;
+  opacity: 1;
+}
+
+.experience-page--roadmap::before {
+  width: 640px;
+  height: 640px;
+  top: -280px;
+  right: -220px;
+  background: radial-gradient(circle at center, rgba(79, 129, 255, 0.22) 0%, rgba(255, 255, 255, 0) 74%);
+}
+
+.experience-page--roadmap::after {
+  width: 560px;
+  height: 560px;
+  bottom: -240px;
+  left: -180px;
+  background: radial-gradient(circle at center, rgba(67, 214, 214, 0.26) 0%, rgba(255, 255, 255, 0) 74%);
+}
+
 .roadmap-panel {
   margin-top: 3rem;
-  background: var(--surface);
-  border: 2px solid var(--color-border-soft);
+  position: relative;
+  background: linear-gradient(160deg, rgba(255, 255, 255, 0.96), rgba(234, 245, 255, 0.9));
+  border: 1px solid rgba(80, 50, 145, 0.18);
   border-radius: 26px;
-  box-shadow: 0 22px 56px rgba(12, 22, 70, 0.12);
+  box-shadow: 0 30px 72px rgba(20, 32, 75, 0.2);
   padding: 2.25rem;
+  overflow: hidden;
+}
+
+.roadmap-panel::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: linear-gradient(145deg, rgba(92, 60, 199, 0.1), rgba(46, 155, 214, 0.08));
+  opacity: 0;
+  transition: opacity 0.25s ease;
+  pointer-events: none;
+  z-index: 0;
+}
+
+.roadmap-panel:hover::before {
+  opacity: 1;
+}
+
+.roadmap-panel > * {
+  position: relative;
+  z-index: 1;
 }
 
 .roadmap-panel__grid {
@@ -16,14 +65,37 @@
 }
 
 .roadmap-card-block {
-  background: linear-gradient(150deg, rgba(255, 255, 255, 0.95), rgba(244, 243, 255, 0.95));
+  position: relative;
+  background: linear-gradient(150deg, rgba(255, 255, 255, 0.97), rgba(236, 242, 255, 0.9));
   border-radius: 22px;
-  border: 1px solid rgba(120, 112, 210, 0.18);
+  border: 1px solid rgba(80, 50, 145, 0.16);
   padding: 1.75rem;
-  box-shadow: 0 18px 36px rgba(18, 28, 70, 0.12);
+  box-shadow: 0 24px 58px rgba(18, 32, 75, 0.16);
   display: flex;
   flex-direction: column;
   gap: 1.5rem;
+  overflow: hidden;
+}
+
+.roadmap-card-block::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: linear-gradient(135deg, rgba(92, 60, 199, 0.08), rgba(46, 155, 214, 0.06));
+  opacity: 0;
+  transition: opacity 0.25s ease;
+  pointer-events: none;
+  z-index: 0;
+}
+
+.roadmap-card-block:hover::before {
+  opacity: 1;
+}
+
+.roadmap-card-block > * {
+  position: relative;
+  z-index: 1;
 }
 
 .roadmap-card-block__header {
@@ -68,21 +140,44 @@
   align-items: flex-start;
   padding: 0.9rem 1rem;
   border-radius: 16px;
-  background: rgba(141, 89, 255, 0.12);
+  background: rgba(79, 129, 255, 0.15);
   color: var(--color-rich-purple);
   font-size: 0.85rem;
 }
 
 .roadmap-insights {
   margin-top: 2.5rem;
+  position: relative;
   padding: 2.25rem;
   border-radius: 28px;
-  border: 2px solid rgba(141, 89, 255, 0.18);
-  background: linear-gradient(165deg, rgba(255, 255, 255, 0.96), rgba(240, 238, 255, 0.96));
-  box-shadow: 0 30px 60px rgba(15, 24, 60, 0.18);
+  border: 1px solid rgba(80, 50, 145, 0.2);
+  background: linear-gradient(170deg, rgba(255, 255, 255, 0.97), rgba(232, 244, 255, 0.92));
+  box-shadow: 0 32px 78px rgba(18, 32, 75, 0.22);
   display: flex;
   flex-direction: column;
   gap: 1.75rem;
+  overflow: hidden;
+}
+
+.roadmap-insights::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: linear-gradient(140deg, rgba(92, 60, 199, 0.08), rgba(46, 155, 214, 0.06));
+  opacity: 0;
+  transition: opacity 0.25s ease;
+  pointer-events: none;
+  z-index: 0;
+}
+
+.roadmap-insights:hover::before {
+  opacity: 1;
+}
+
+.roadmap-insights > * {
+  position: relative;
+  z-index: 1;
 }
 
 .roadmap-insights__header {
@@ -95,12 +190,12 @@
   width: 44px;
   height: 44px;
   border-radius: 14px;
-  background: var(--color-sensitive-blue);
+  background: linear-gradient(135deg, rgba(79, 129, 255, 0.22), rgba(46, 155, 214, 0.22));
   display: inline-flex;
   align-items: center;
   justify-content: center;
   color: var(--color-rich-purple);
-  box-shadow: 0 10px 20px rgba(80, 120, 255, 0.25);
+  box-shadow: 0 16px 32px rgba(44, 106, 178, 0.22);
 }
 
 .roadmap-insights__header h2 {
@@ -144,11 +239,36 @@
 }
 
 .roadmap-group {
-  border: 2px solid rgba(141, 89, 255, 0.18);
+  --roadmap-accent: var(--color-rich-purple);
+  position: relative;
+  border: 1px solid rgba(80, 50, 145, 0.2);
   border-radius: 22px;
   padding: 1.5rem;
-  background: rgba(255, 255, 255, 0.95);
+  background: linear-gradient(150deg, rgba(255, 255, 255, 0.96), rgba(236, 243, 255, 0.92));
   margin-bottom: 1.25rem;
+  box-shadow: 0 24px 58px rgba(18, 32, 75, 0.18);
+  overflow: hidden;
+}
+
+.roadmap-group::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: linear-gradient(140deg, rgba(92, 60, 199, 0.08), rgba(46, 155, 214, 0.06));
+  opacity: 0;
+  transition: opacity 0.25s ease;
+  pointer-events: none;
+  z-index: 0;
+}
+
+.roadmap-group:hover::before {
+  opacity: 1;
+}
+
+.roadmap-group > * {
+  position: relative;
+  z-index: 1;
 }
 
 .roadmap-group__header {
@@ -156,7 +276,7 @@
   align-items: center;
   gap: 0.65rem;
   font-weight: 700;
-  color: var(--color-rich-purple);
+  color: var(--roadmap-accent);
   margin-bottom: 1rem;
 }
 
@@ -164,16 +284,17 @@
   width: 32px;
   height: 32px;
   border-radius: 12px;
-  background: rgba(141, 89, 255, 0.14);
+  background: rgba(80, 50, 145, 0.16);
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  color: var(--roadmap-accent);
 }
 
 .roadmap-group__count {
   margin-left: auto;
   font-size: 0.8rem;
-  color: var(--muted);
+  color: rgba(0, 0, 0, 0.4);
 }
 
 .roadmap-group__grid {
@@ -182,15 +303,105 @@
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
 }
 
+.roadmap-group.tone-green {
+  --roadmap-accent: var(--color-rich-green);
+  border-color: rgba(20, 155, 95, 0.28);
+  box-shadow: 0 26px 62px rgba(20, 155, 95, 0.16);
+}
+
+.roadmap-group.tone-green::before {
+  background: linear-gradient(140deg, rgba(20, 155, 95, 0.14), rgba(46, 155, 214, 0.08));
+}
+
+.roadmap-group.tone-yellow {
+  --roadmap-accent: var(--color-vibrant-yellow);
+  border-color: rgba(255, 200, 50, 0.28);
+  box-shadow: 0 26px 62px rgba(255, 200, 50, 0.18);
+}
+
+.roadmap-group.tone-yellow::before {
+  background: linear-gradient(140deg, rgba(255, 200, 50, 0.16), rgba(79, 129, 255, 0.08));
+}
+
+.roadmap-group.tone-red {
+  --roadmap-accent: var(--color-rich-red);
+  border-color: rgba(230, 30, 80, 0.28);
+  box-shadow: 0 26px 62px rgba(230, 30, 80, 0.16);
+}
+
+.roadmap-group.tone-red::before {
+  background: linear-gradient(140deg, rgba(230, 30, 80, 0.15), rgba(92, 60, 199, 0.08));
+}
+
+.roadmap-group.tone-lilac {
+  --roadmap-accent: var(--color-vibrant-magenta);
+  border-color: rgba(235, 60, 150, 0.26);
+  box-shadow: 0 26px 62px rgba(166, 76, 206, 0.16);
+}
+
+.roadmap-group.tone-lilac::before {
+  background: linear-gradient(140deg, rgba(235, 60, 150, 0.14), rgba(46, 155, 214, 0.08));
+}
+
+.roadmap-group.tone-lilac .roadmap-group__icon {
+  background: rgba(235, 60, 150, 0.18);
+}
+
+.roadmap-group.tone-green .roadmap-group__icon {
+  background: rgba(20, 155, 95, 0.18);
+}
+
+.roadmap-group.tone-yellow .roadmap-group__icon {
+  background: rgba(255, 200, 50, 0.22);
+}
+
+.roadmap-group.tone-red .roadmap-group__icon {
+  background: rgba(230, 30, 80, 0.18);
+}
+
 .roadmap-card {
+  position: relative;
   border-radius: 20px;
-  border: 1px solid rgba(141, 89, 255, 0.2);
-  background: rgba(255, 255, 255, 0.96);
+  border: 1px solid rgba(80, 50, 145, 0.18);
+  background: linear-gradient(150deg, rgba(255, 255, 255, 0.98), rgba(236, 243, 255, 0.94));
   padding: 1.1rem 1.25rem;
-  box-shadow: 0 12px 30px rgba(20, 30, 70, 0.12);
+  box-shadow: 0 20px 48px rgba(20, 32, 75, 0.18);
   display: flex;
   flex-direction: column;
   gap: 0.8rem;
+  overflow: hidden;
+}
+
+.roadmap-card::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: linear-gradient(120deg, rgba(92, 60, 199, 0.08), rgba(46, 155, 214, 0.04));
+  opacity: 0;
+  transition: opacity 0.2s ease;
+  pointer-events: none;
+  z-index: 0;
+}
+
+.roadmap-card::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 5px;
+  background: var(--roadmap-accent);
+  opacity: 0.9;
+}
+
+.roadmap-card:hover::before {
+  opacity: 1;
+}
+
+.roadmap-card > * {
+  position: relative;
+  z-index: 1;
 }
 
 .roadmap-card__header {
@@ -214,7 +425,7 @@
 .roadmap-card__gap {
   font-size: 0.8rem;
   font-weight: 600;
-  color: var(--color-rich-purple);
+  color: var(--roadmap-accent);
 }
 
 .roadmap-card__footer {
@@ -235,7 +446,7 @@
   align-items: center;
   gap: 0.5rem;
   font-size: 0.8rem;
-  color: var(--color-rich-purple);
+  color: var(--roadmap-accent);
 }
 
 .roadmap-results {
@@ -257,14 +468,38 @@
 }
 
 .roadmap-recommendation {
+  --roadmap-reco-accent: var(--color-rich-purple);
+  position: relative;
   border-radius: 22px;
-  border: 1px solid rgba(141, 89, 255, 0.2);
-  background: rgba(255, 255, 255, 0.95);
+  border: 1px solid rgba(80, 50, 145, 0.2);
+  background: linear-gradient(155deg, rgba(255, 255, 255, 0.96), rgba(236, 243, 255, 0.92));
   padding: 1.3rem 1.5rem;
-  box-shadow: 0 16px 40px rgba(16, 26, 70, 0.14);
+  box-shadow: 0 26px 60px rgba(16, 32, 72, 0.18);
   display: flex;
   flex-direction: column;
   gap: 0.8rem;
+  overflow: hidden;
+}
+
+.roadmap-recommendation::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: linear-gradient(140deg, rgba(92, 60, 199, 0.08), rgba(46, 155, 214, 0.06));
+  opacity: 0;
+  transition: opacity 0.2s ease;
+  pointer-events: none;
+  z-index: 0;
+}
+
+.roadmap-recommendation:hover::before {
+  opacity: 1;
+}
+
+.roadmap-recommendation > * {
+  position: relative;
+  z-index: 1;
 }
 
 .roadmap-recommendation__header {
@@ -274,11 +509,69 @@
   gap: 1rem;
 }
 
+.roadmap-recommendation__header h3 {
+  margin: 0;
+  color: var(--roadmap-reco-accent);
+}
+
+.roadmap-recommendation__header span {
+  font-weight: 600;
+}
+
+.roadmap-recommendation.tone-green {
+  --roadmap-reco-accent: var(--color-rich-green);
+  border-color: rgba(20, 155, 95, 0.32);
+  box-shadow: 0 28px 64px rgba(20, 155, 95, 0.2);
+}
+
+.roadmap-recommendation.tone-green::before {
+  background: linear-gradient(140deg, rgba(20, 155, 95, 0.15), rgba(46, 155, 214, 0.08));
+}
+
+.roadmap-recommendation.tone-yellow {
+  --roadmap-reco-accent: var(--color-vibrant-yellow);
+  border-color: rgba(255, 200, 50, 0.32);
+  box-shadow: 0 28px 64px rgba(255, 200, 50, 0.22);
+}
+
+.roadmap-recommendation.tone-yellow::before {
+  background: linear-gradient(140deg, rgba(255, 200, 50, 0.18), rgba(79, 129, 255, 0.08));
+}
+
+.roadmap-recommendation.tone-lilac {
+  --roadmap-reco-accent: var(--color-vibrant-magenta);
+  border-color: rgba(235, 60, 150, 0.28);
+  box-shadow: 0 28px 64px rgba(166, 76, 206, 0.2);
+}
+
+.roadmap-recommendation.tone-lilac::before {
+  background: linear-gradient(140deg, rgba(235, 60, 150, 0.16), rgba(46, 155, 214, 0.08));
+}
+
+.roadmap-recommendation.tone-blue {
+  --roadmap-reco-accent: var(--color-rich-blue);
+  border-color: rgba(47, 138, 220, 0.32);
+  box-shadow: 0 28px 64px rgba(47, 138, 220, 0.22);
+}
+
+.roadmap-recommendation.tone-blue::before {
+  background: linear-gradient(140deg, rgba(47, 138, 220, 0.18), rgba(92, 60, 199, 0.08));
+}
+
+.roadmap-recommendation.tone-neutral {
+  --roadmap-reco-accent: var(--color-rich-purple);
+  border-color: rgba(80, 50, 145, 0.24);
+}
+
 .roadmap-recommendation__summary {
   font-size: 0.85rem;
   color: var(--color-rich-purple);
   display: grid;
   gap: 0.35rem;
+}
+
+.roadmap-recommendation__summary strong {
+  color: var(--roadmap-reco-accent);
 }
 
 .roadmap-recommendation__actions {
@@ -376,6 +669,65 @@
 }
 
 .field { position: relative; display: flex; flex-direction: column; gap: 6px; }
+
+.field--elevated {
+  gap: 0.75rem;
+}
+
+.field__label {
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-weight: 700;
+  color: rgba(80, 50, 145, 0.82);
+}
+
+.field__control {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.7rem 0.9rem;
+  border-radius: 18px;
+  border: 1px solid rgba(80, 50, 145, 0.22);
+  background: rgba(255, 255, 255, 0.94);
+  box-shadow: 0 18px 40px rgba(20, 32, 75, 0.15);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+.field__control:focus-within {
+  border-color: rgba(45, 190, 205, 0.65);
+  box-shadow: 0 22px 48px rgba(45, 190, 205, 0.25);
+  transform: translateY(-1px);
+}
+
+.field__icon {
+  color: var(--color-rich-purple);
+  opacity: 0.8;
+}
+
+.input--elevated {
+  flex: 1;
+  border: 0;
+  background: transparent;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--color-rich-purple);
+  padding: 0.2rem 0;
+  appearance: none;
+}
+
+.input--elevated:focus {
+  outline: none;
+}
+
+.field__control select.input--elevated {
+  padding-right: 2rem;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='6' viewBox='0 0 10 6'%3E%3Cpath fill='%23503291' d='M5 6L0 0h10z'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 0.65rem center;
+  background-size: 10px 6px;
+}
 
 .input {
   width: 100%;


### PR DESCRIPTION
## Summary
- refresh the shared button system with gradient fills, softer borders, and updated hover treatments for each variant
- restyle the explorer hero, controls, and recommendation cards with lighter gradients and shadow treatments
- reskin the roadmap experience with toned groups, accent bars, and elevated form controls for both planner and recommendations

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d0e1544ad8832dbaad19c08a735e45