### PR TITLE
Remove gradients and shadows from explorer UI

### DIFF
--- a/src/styles/components/buttons.css
+++ b/src/styles/components/buttons.css
@@ -12,27 +12,26 @@
   gap: 0.5rem;
   padding: 0.65rem 1.1rem;
   border-radius: 14px;
-  border: 1px solid rgba(80, 50, 145, 0.22);
+  border: 2px solid var(--color-rich-purple);
   cursor: pointer;
   font-weight: 700;
   font-size: 0.9375rem;
   letter-spacing: 0.01em;
-  transition: transform 0.18s ease, box-shadow 0.18s ease,
-    background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
-  background: linear-gradient(140deg, rgba(255, 255, 255, 0.95), rgba(241, 237, 255, 0.9));
+  transition: transform 0.18s ease, background 0.2s ease, color 0.2s ease,
+    border-color 0.2s ease;
+  background: var(--color-neutral-white);
   color: var(--color-rich-purple);
-  box-shadow: 0 14px 32px rgba(32, 32, 72, 0.12);
 }
 
 .button:hover,
 .btn:hover {
   transform: translateY(-2px);
-  box-shadow: 0 22px 50px rgba(32, 32, 72, 0.16);
+  background: var(--color-sensitive-yellow);
 }
 
 .button:focus-visible,
 .btn:focus-visible {
-  outline: 3px solid rgba(45, 190, 205, 0.4);
+  outline: 3px solid var(--color-vibrant-cyan);
   outline-offset: 2px;
 }
 
@@ -46,17 +45,15 @@
 
 .button--primary,
 .btn.primary {
-  background: linear-gradient(135deg, #6a4ae0, #2f9adf);
+  background: var(--color-rich-purple);
   color: var(--color-text-inverse);
-  border-color: transparent;
-  box-shadow: 0 26px 56px rgba(71, 61, 160, 0.45);
+  border-color: var(--color-rich-purple);
 }
 
 .button--primary:hover,
 .btn.primary:hover {
   transform: translateY(-3px);
-  box-shadow: 0 32px 64px rgba(71, 61, 160, 0.5);
-  filter: brightness(1.05);
+  background: var(--color-rich-blue);
 }
 
 .button--primary:focus-visible,
@@ -67,30 +64,30 @@
 
 .button--secondary,
 .btn.secondary {
-  background: linear-gradient(135deg, #ffe9a9, #ffd46a);
+  background: var(--color-vibrant-yellow);
   color: var(--color-rich-purple);
-  border-color: rgba(255, 210, 102, 0.6);
-  box-shadow: 0 18px 40px rgba(205, 168, 70, 0.25);
+  border-color: var(--color-rich-purple);
 }
 
 .button--secondary:hover,
 .btn.secondary:hover {
   transform: translateY(-3px);
-  box-shadow: 0 26px 56px rgba(205, 168, 70, 0.3);
+  background: var(--color-vibrant-green);
+  color: var(--color-neutral-white);
+  border-color: var(--color-rich-green);
 }
 
 .button--ghost,
 .btn.ghost {
-  background: rgba(80, 50, 145, 0.08);
+  background: var(--color-sensitive-blue);
   color: var(--color-rich-purple);
-  border-color: rgba(80, 50, 145, 0.28);
-  box-shadow: 0 10px 26px rgba(80, 50, 145, 0.12);
+  border-color: var(--color-rich-blue);
 }
 
 .button--ghost:hover,
 .btn.ghost:hover {
-  background: rgba(80, 50, 145, 0.14);
-  box-shadow: 0 16px 34px rgba(80, 50, 145, 0.18);
+  background: var(--color-sensitive-green);
+  border-color: var(--color-rich-green);
 }
 
 .button--ghost:focus-visible,
@@ -100,15 +97,14 @@
 }
 
 .button--inverse {
-  background: linear-gradient(140deg, #ffffff, #f2f5ff);
+  background: var(--color-neutral-white);
   color: var(--color-rich-purple);
-  border-color: rgba(80, 50, 145, 0.16);
-  box-shadow: 0 28px 60px rgba(20, 32, 70, 0.28);
+  border-color: var(--color-rich-purple);
 }
 
 .button--inverse:hover {
   transform: translateY(-3px);
-  box-shadow: 0 36px 72px rgba(20, 32, 70, 0.32);
+  background: var(--color-sensitive-yellow);
 }
 
 .button--inverse:focus-visible {
@@ -118,17 +114,17 @@
 
 .button--fun,
 .btn.fun {
-  background: linear-gradient(135deg, #ff5aa5, #ff7a5c);
+  background: var(--color-vibrant-magenta);
   color: var(--color-text-inverse);
-  border: 0;
+  border: 2px solid var(--color-vibrant-magenta);
   padding: 0.65rem 1.25rem;
-  box-shadow: 0 24px 48px rgba(204, 66, 109, 0.38);
 }
 
 .button--fun:hover,
 .btn.fun:hover {
   transform: translateY(-3px);
-  box-shadow: 0 32px 64px rgba(204, 66, 109, 0.42);
+  background: var(--color-rich-red);
+  border-color: var(--color-rich-red);
 }
 
 .button--fun:focus-visible,
@@ -150,51 +146,49 @@
 }
 
 .icon-button {
-  background: rgba(45, 190, 205, 0.16);
+  background: var(--color-sensitive-blue);
   color: var(--color-rich-purple);
-  border: 1px solid rgba(45, 190, 205, 0.36);
+  border: 1px solid var(--color-rich-blue);
   padding: 0.375rem 0.5rem;
   border-radius: 12px;
   cursor: pointer;
-  transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
-  box-shadow: 0 10px 24px rgba(28, 116, 130, 0.18);
+  transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
 }
 
 .icon-button:hover {
-  background: rgba(45, 190, 205, 0.24);
-  box-shadow: 0 16px 34px rgba(28, 116, 130, 0.22);
+  background: var(--color-sensitive-green);
+  border-color: var(--color-rich-green);
 }
 
 .badge {
   font-size: 0.75rem;
   padding: 0.3rem 0.8rem;
   border-radius: 999px;
-  border: 1px solid rgba(80, 50, 145, 0.24);
+  border: 1px solid var(--color-rich-purple);
   font-weight: 600;
   display: inline-flex;
   align-items: center;
   gap: 0.4rem;
-  background: rgba(80, 50, 145, 0.08);
+  background: var(--color-sensitive-pink);
   color: var(--color-rich-purple);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
 }
 
 .badge.green {
-  background: rgba(20, 155, 95, 0.14);
+  background: var(--color-sensitive-green);
   color: var(--color-rich-green);
-  border-color: rgba(20, 155, 95, 0.3);
+  border-color: var(--color-rich-green);
 }
 
 .badge.yellow {
-  background: rgba(255, 200, 50, 0.18);
+  background: var(--color-sensitive-yellow);
   color: var(--color-rich-purple);
-  border-color: rgba(255, 200, 50, 0.4);
+  border-color: var(--color-vibrant-yellow);
 }
 
 .badge.purple {
-  background: linear-gradient(135deg, #6a4ae0, #4c70f0);
+  background: var(--color-rich-purple);
   color: var(--color-text-inverse);
-  border-color: transparent;
+  border-color: var(--color-rich-purple);
 }
 
 .badge.solid {
@@ -202,21 +196,21 @@
 }
 
 .badge.solid.green {
-  background: linear-gradient(135deg, #3bc47b, #16a05d);
+  background: var(--color-rich-green);
   color: var(--color-text-inverse);
 }
 
 .badge.solid.yellow {
-  background: linear-gradient(135deg, #ffd65d, #ffb71b);
+  background: var(--color-vibrant-yellow);
   color: var(--color-rich-purple);
 }
 
 .badge.solid.orange {
-  background: linear-gradient(135deg, #ff6bb5, #ff508a);
+  background: var(--color-vibrant-magenta);
   color: var(--color-text-inverse);
 }
 
 .badge.solid.gray {
-  background: rgba(80, 50, 145, 0.14);
-  color: var(--color-rich-purple);
+  background: var(--color-sensitive-blue);
+  color: var(--color-rich-blue);
 }

--- a/src/styles/layouts/career-explorer.css
+++ b/src/styles/layouts/career-explorer.css
@@ -2,9 +2,9 @@
 
 .explorer-page {
   background: var(--color-rich-purple);
-  --explorer-card-surface: #efe7ff;
-  --explorer-card-surface-strong: #e1d8ff;
-  --explorer-card-border: rgba(80, 50, 145, 0.35);
+  --explorer-card-surface: var(--color-sensitive-yellow);
+  --explorer-card-surface-strong: var(--color-sensitive-blue);
+  --explorer-card-border: var(--color-rich-purple);
 }
 
 .explorer-page .hero {
@@ -20,7 +20,6 @@
   flex-direction: column;
   gap: 1.1rem;
   backdrop-filter: blur(14px);
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
 }
 
 .explorer-hero__status-heading {
@@ -90,7 +89,7 @@
   letter-spacing: 0.01em;
   appearance: none;
   backdrop-filter: blur(8px);
-  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  transition: border-color 0.2s ease;
 }
 
 .explorer-hero__select:hover {
@@ -98,9 +97,9 @@
 }
 
 .explorer-hero__select:focus {
-  outline: none;
+  outline: 3px solid var(--color-vibrant-cyan);
+  outline-offset: 2px;
   border-color: var(--color-vibrant-cyan);
-  box-shadow: 0 0 0 3px rgba(86, 229, 255, 0.32);
 }
 
 .explorer-hero__chevron {
@@ -190,12 +189,11 @@
 .explorer-panel {
   position: relative;
   background: var(--explorer-card-surface);
-  border: 1px solid rgba(80, 50, 145, 0.22);
+  border: 1px solid var(--color-rich-purple);
   border-radius: 32px;
   padding: clamp(1.8rem, 3vw, 2.75rem);
   display: grid;
   gap: 2rem;
-  box-shadow: 0 28px 70px rgba(24, 14, 60, 0.2);
   overflow: hidden;
 }
 
@@ -213,9 +211,9 @@
   gap: 0.5rem;
   padding: 0.3rem 0.85rem;
   border-radius: 999px;
-  background: rgba(80, 50, 145, 0.12);
+  background: var(--color-sensitive-pink);
   color: var(--color-rich-purple);
-  border: 1px solid rgba(80, 50, 145, 0.25);
+  border: 1px solid var(--color-rich-purple);
   text-transform: uppercase;
   font-size: 0.75rem;
   letter-spacing: 0.08em;
@@ -242,13 +240,13 @@
   gap: 0.35rem;
   padding: 0.35rem 0.85rem;
   border-radius: 999px;
-  border: 1px solid rgba(80, 50, 145, 0.3);
+  border: 1px solid var(--color-rich-purple);
   font-size: 0.75rem;
   font-weight: 700;
   letter-spacing: 0.08em;
   text-transform: uppercase;
   color: var(--color-rich-purple);
-  background: rgba(80, 50, 145, 0.08);
+  background: var(--color-sensitive-blue);
 }
 
 .explorer-panel__controls {
@@ -267,7 +265,7 @@
   font-weight: 700;
   letter-spacing: 0.05em;
   text-transform: uppercase;
-  color: rgba(80, 50, 145, 0.85);
+  color: var(--color-rich-purple);
 }
 
 .explorer-control__field {
@@ -276,15 +274,13 @@
   gap: 0.75rem;
   padding: 0.75rem 1rem;
   border-radius: 20px;
-  border: 1px solid rgba(80, 50, 145, 0.22);
-  background: rgba(255, 255, 255, 0.92);
-  box-shadow: 0 16px 34px rgba(30, 41, 80, 0.12);
-  transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+  border: 1px solid var(--color-rich-purple);
+  background: var(--color-neutral-white);
+  transition: border-color 0.2s ease, transform 0.2s ease;
 }
 
 .explorer-control__field:focus-within {
-  border-color: rgba(45, 190, 205, 0.65);
-  box-shadow: 0 18px 40px rgba(45, 190, 205, 0.25);
+  border-color: var(--color-vibrant-cyan);
   transform: translateY(-1px);
 }
 
@@ -361,7 +357,6 @@
   display: block;
   opacity: 1;
   background: rgba(255, 255, 255, 0.12);
-  box-shadow: 0 0 140px rgba(255, 255, 255, 0.12);
 }
 
 .experience-page--explorer::before {
@@ -387,7 +382,6 @@
 .experience-page--explorer .experience-hero {
   border: 1px solid rgba(255, 255, 255, 0.3);
   background: var(--color-rich-purple);
-  box-shadow: 0 46px 110px rgba(16, 10, 40, 0.55);
   overflow: hidden;
 }
 
@@ -419,7 +413,6 @@
 
 .experience-page--explorer .experience-hero__icon {
   background: rgba(255, 255, 255, 0.22);
-  box-shadow: 0 22px 50px rgba(16, 10, 40, 0.45);
 }
 
 .experience-page--explorer .experience-hero__title {
@@ -433,7 +426,6 @@
 .experience-page--explorer .experience-hero__status-card {
   background: rgba(255, 255, 255, 0.16);
   border: 1px solid rgba(255, 255, 255, 0.32);
-  box-shadow: 0 24px 54px rgba(16, 10, 40, 0.45);
   color: var(--color-neutral-white);
   backdrop-filter: blur(12px);
 }
@@ -452,31 +444,31 @@
   flex-wrap: wrap;
 }
 
+
 .experience-page--explorer .experience-hero__actions .button--inverse {
   background: var(--color-neutral-white);
   color: var(--color-rich-purple);
-  border-color: rgba(255, 255, 255, 0.4);
+  border-color: var(--color-neutral-white);
 }
 
 .experience-page--explorer .experience-hero__actions .button--ghost {
-  background: rgba(255, 255, 255, 0.16);
-  border-color: rgba(255, 255, 255, 0.35);
+  background: var(--color-sensitive-blue);
+  border-color: var(--color-neutral-white);
   color: var(--color-neutral-white);
 }
 
 .experience-page--explorer .experience-hero__actions .button--ghost:hover {
-  background: rgba(255, 255, 255, 0.26);
+  background: var(--color-vibrant-cyan);
 }
 
 .experience-page--explorer .chip-link {
-  background: rgba(255, 255, 255, 0.18);
-  border: 1px solid rgba(255, 255, 255, 0.32);
+  background: var(--color-sensitive-blue);
+  border: 1px solid var(--color-neutral-white);
   color: var(--color-neutral-white);
 }
 
 .experience-page--explorer .chip-link:hover {
   transform: translateY(-2px);
-  box-shadow: none;
   color: var(--color-neutral-white);
 }
 
@@ -490,7 +482,6 @@
   display: flex;
   flex-direction: column;
   gap: 2rem;
-  box-shadow: 0 34px 80px rgba(24, 14, 60, 0.25);
 }
 
 .explorer-toolbar__header {
@@ -515,13 +506,12 @@
 
 .toolbar-control {
   flex: 1 1 280px;
-  background: rgba(255, 255, 255, 0.95);
+  background: var(--color-neutral-white);
   border-radius: 28px;
   padding: 1.25rem 1.5rem;
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
-  box-shadow: 0 26px 60px rgba(12, 22, 60, 0.24);
 }
 
 .toolbar-control__label {
@@ -537,16 +527,14 @@
   align-items: center;
   gap: 0.9rem;
   border-radius: 18px;
-  border: 1px solid rgba(80, 50, 145, 0.22);
+  border: 1px solid var(--color-rich-purple);
   padding: 0.65rem 0.85rem;
-  background: rgba(255, 255, 255, 0.92);
-  box-shadow: 0 14px 30px rgba(24, 32, 72, 0.14);
-  transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+  background: var(--color-neutral-white);
+  transition: border-color 0.2s ease, transform 0.2s ease;
 }
 
 .toolbar-control__field:focus-within {
-  border-color: rgba(45, 190, 205, 0.65);
-  box-shadow: 0 18px 40px rgba(45, 190, 205, 0.25);
+  border-color: var(--color-vibrant-cyan);
   transform: translateY(-1px);
 }
 
@@ -623,7 +611,6 @@
   border-radius: 28px;
   background: var(--explorer-card-surface);
   border: 1px solid var(--explorer-card-border);
-  box-shadow: 0 22px 44px rgba(24, 14, 60, 0.18);
 }
 
 .explorer-group__header {
@@ -664,8 +651,7 @@
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
-  box-shadow: 0 16px 36px rgba(24, 14, 60, 0.16);
-  transition: transform 0.25s ease, box-shadow 0.25s ease, border-color 0.25s ease;
+  transition: transform 0.25s ease, border-color 0.25s ease;
 }
 
 .explorer-card__title {
@@ -688,7 +674,6 @@
 .explorer-card.is-active {
   transform: translateY(-6px);
   border-color: var(--color-rich-blue);
-  box-shadow: 0 18px 38px rgba(47, 138, 220, 0.18);
 }
 
 
@@ -697,7 +682,6 @@
   border-radius: 30px;
   border: 1px solid var(--explorer-card-border);
   background: var(--explorer-card-surface-strong);
-  box-shadow: 0 32px 65px rgba(24, 14, 60, 0.28);
   position: sticky;
   top: 2rem;
   align-self: start;
@@ -814,7 +798,6 @@
   display: flex;
   flex-direction: column;
   gap: 0.65rem;
-  box-shadow: 0 26px 60px rgba(24, 14, 60, 0.18);
   overflow: hidden;
 }
 
@@ -847,29 +830,39 @@
   gap: 0.35rem;
 }
 
-.explorer-similar.tone-green {
-  border-color: rgba(20, 155, 95, 0.32);
-  box-shadow: 0 28px 60px rgba(20, 155, 95, 0.18);
+.explorer-card.tone-green,
+.explorer-similar.tone-green,
+.explorer-recommendation.tone-green {
+  border-color: var(--color-rich-green);
+  background: var(--color-sensitive-green);
 }
 
-.explorer-similar.tone-yellow {
-  border-color: rgba(255, 200, 50, 0.32);
-  box-shadow: 0 28px 60px rgba(255, 200, 50, 0.2);
+.explorer-card.tone-yellow,
+.explorer-similar.tone-yellow,
+.explorer-recommendation.tone-yellow {
+  border-color: var(--color-vibrant-yellow);
+  background: var(--color-sensitive-yellow);
 }
 
-.explorer-similar.tone-lilac {
-  border-color: rgba(235, 60, 150, 0.28);
-  box-shadow: 0 28px 60px rgba(166, 76, 206, 0.18);
+.explorer-card.tone-lilac,
+.explorer-similar.tone-lilac,
+.explorer-recommendation.tone-lilac {
+  border-color: var(--color-vibrant-magenta);
+  background: var(--color-sensitive-pink);
 }
 
-.explorer-similar.tone-blue {
-  border-color: rgba(47, 138, 220, 0.32);
-  box-shadow: 0 28px 60px rgba(47, 138, 220, 0.2);
+.explorer-card.tone-blue,
+.explorer-similar.tone-blue,
+.explorer-recommendation.tone-blue {
+  border-color: var(--color-rich-blue);
+  background: var(--color-sensitive-blue);
 }
 
-.explorer-similar.tone-red {
-  border-color: rgba(230, 30, 80, 0.3);
-  box-shadow: 0 28px 60px rgba(230, 30, 80, 0.18);
+.explorer-card.tone-red,
+.explorer-similar.tone-red,
+.explorer-recommendation.tone-red {
+  border-color: var(--color-rich-red);
+  background: var(--color-sensitive-pink);
 }
 
 .explorer-recommendations {
@@ -881,7 +874,6 @@
   border-radius: 28px;
   padding: 2rem;
   border: 1px solid var(--explorer-card-border);
-  box-shadow: 0 24px 56px rgba(24, 14, 60, 0.18);
 }
 
 .explorer-recommendations__header {
@@ -910,7 +902,6 @@
   border: 1px solid var(--explorer-card-border);
   background: var(--explorer-card-surface);
   padding: 1.35rem 1.5rem;
-  box-shadow: 0 28px 64px rgba(24, 14, 60, 0.2);
   display: flex;
   flex-direction: column;
   gap: 0.9rem;
@@ -957,30 +948,6 @@
   flex: 1 1 150px;
 }
 
-.explorer-recommendation.tone-green {
-  border-color: rgba(20, 155, 95, 0.35);
-  box-shadow: 0 30px 64px rgba(20, 155, 95, 0.2);
-}
-
-.explorer-recommendation.tone-yellow {
-  border-color: rgba(255, 200, 50, 0.35);
-  box-shadow: 0 30px 64px rgba(255, 200, 50, 0.22);
-}
-
-.explorer-recommendation.tone-lilac {
-  border-color: rgba(235, 60, 150, 0.3);
-  box-shadow: 0 30px 64px rgba(166, 76, 206, 0.2);
-}
-
-.explorer-recommendation.tone-blue {
-  border-color: rgba(47, 138, 220, 0.35);
-  box-shadow: 0 30px 64px rgba(47, 138, 220, 0.22);
-}
-
-.explorer-recommendation.tone-red {
-  border-color: rgba(230, 30, 80, 0.35);
-  box-shadow: 0 30px 64px rgba(230, 30, 80, 0.2);
-}
 
 @media (max-width: 960px) {
   .experience-page--explorer .container {

--- a/src/utils/jobDataUtils.js
+++ b/src/utils/jobDataUtils.js
@@ -170,9 +170,9 @@ export function summarizeTransition(currentJob, targetJob, maxItems = 3) {
 export function getSimilarityBadge(score) {
   if (score >= 90) return { label: 'Excellent', color: 'badge solid green' };
   if (score >= 80) return { label: 'Great', color: 'badge solid yellow' };
-  if (score >= 70) return { label: 'Good', color: 'badge solid orange' };
-  if (score >= 60) return { label: 'Emerging', color: 'badge solid purple' };
-  return { label: 'Early Match', color: 'badge solid gray' };
+  if (score >= 70) return { label: 'Good', color: 'badge green' };
+  if (score >= 60) return { label: 'Emerging', color: 'badge purple' };
+  return { label: 'Early Match', color: 'badge yellow' };
 }
 
 export function getTrainingRecommendations(skillName, typeOrGuess, gap) {


### PR DESCRIPTION
## Summary
- restyle the shared button system to remove gradients and shadows while using solid Merck palette colors for variants and badges
- retheme the career explorer layout so cards and controls use sensitive Merck tones without drop shadows, including updated tone classes
- adjust similarity badge colours so good matches use green and early matches use yellow as requested

## Testing
- npm test -- --watchAll=false --passWithNoTests

------
https://chatgpt.com/codex/tasks/task_e_68d0eb13c710832db539e33a6f83475f