### PR TITLE
Expand explorer cards with snapshots and simplify hero

### DIFF
--- a/src/components/JobSkillsMatcher.jsx
+++ b/src/components/JobSkillsMatcher.jsx
@@ -32,6 +32,14 @@ function getSimilarityTone(sim) {
   return 'tone-neutral';
 }
 
+function formatSnapshot(text, limit = 150) {
+  if (!text) return '';
+  const clean = text.replace(/\s+/g, ' ').trim();
+  if (!clean) return '';
+  if (clean.length <= limit) return clean;
+  return `${clean.slice(0, limit - 1).trimEnd()}…`;
+}
+
 /* ------------------------- Main Component (Single Page) ------------------------- */
 const JobSkillsMatcher = () => {
   const navigate = useNavigate();
@@ -525,6 +533,7 @@ const JobSkillsMatcher = () => {
                           const similarity = myPosition ? simScore(myPosition, job) : null;
                           const toneClass = similarity != null ? getSimilarityTone(similarity) : 'tone-neutral';
                           const badge = similarity != null ? getSimilarityBadge(similarity) : null;
+                          const snapshot = formatSnapshot(job.description);
 
                           return (
                             <button
@@ -535,9 +544,21 @@ const JobSkillsMatcher = () => {
                               aria-pressed={isSelected}
                               title={`Open ${job.title}`}
                             >
-                              <span className="explorer-card__title">{job.title}</span>
-                              <span className="explorer-card__meta">{job.division}</span>
-                              {badge && <span className={`explorer-card__badge ${badge.color}`}>{badge.label}</span>}
+                              <div className="explorer-card__top">
+                                <div className="explorer-card__info">
+                                  <span className="explorer-card__title">{job.title}</span>
+                                  <span className="explorer-card__meta">{job.division}</span>
+                                </div>
+                                {badge && (
+                                  <span className={`explorer-card__badge ${badge.color}`}>{badge.label}</span>
+                                )}
+                              </div>
+                              {snapshot && (
+                                <div className="explorer-card__snapshot">
+                                  <span className="explorer-card__snapshot-label">Role snapshot</span>
+                                  <p className="explorer-card__description">{snapshot}</p>
+                                </div>
+                              )}
                             </button>
                           );
                         })}

--- a/src/styles/components/hero.css
+++ b/src/styles/components/hero.css
@@ -8,8 +8,8 @@
   position: relative;
   overflow: hidden;
   padding: 7rem 0 5rem;
-  background: var(--color-rich-purple);
-  color: var(--color-text-inverse);
+  background: var(--color-neutral-white);
+  color: var(--color-text);
 }
 
 .hero::before,
@@ -21,21 +21,23 @@
 }
 
 .hero::before {
-  width: 420px;
-  height: 420px;
-  top: -200px;
-  right: -160px;
-  background: var(--color-sensitive-blue);
-  animation: heroGlowShift 14s ease-in-out infinite;
+  width: 520px;
+  height: 520px;
+  top: -260px;
+  right: -180px;
+  background: rgba(150, 215, 210, 0.45);
+  box-shadow: 0 0 160px rgba(150, 215, 210, 0.35);
+  animation: heroFloat 20s ease-in-out infinite;
 }
 
 .hero::after {
   width: 360px;
   height: 360px;
-  bottom: -200px;
-  left: -160px;
-  background: var(--color-sensitive-pink);
-  animation: heroGlowShift 12s ease-in-out infinite reverse;
+  bottom: -160px;
+  left: -140px;
+  background: rgba(255, 255, 255, 0.85);
+  box-shadow: 0 0 140px rgba(150, 215, 210, 0.25);
+  animation: heroFloat 24s ease-in-out infinite reverse;
 }
 
 .hero__inner {
@@ -69,13 +71,14 @@
 .hero__title {
   font-size: clamp(2.5rem, 4vw, 3.75rem);
   margin: 1rem 0;
-  color: var(--color-vibrant-yellow);
+  color: var(--color-rich-purple);
   line-height: 1.05;
 }
 
 .hero__text {
   font-size: 1.05rem;
   margin-bottom: 2rem;
+  color: var(--color-muted);
 }
 
 .hero__actions {
@@ -121,79 +124,82 @@
   position: relative;
   width: clamp(280px, 32vw, 420px);
   aspect-ratio: 1 / 1;
-  border-radius: 32px;
+  border-radius: 50%;
   background: var(--color-sensitive-blue);
-  border: 4px solid var(--color-vibrant-cyan);
-  box-shadow: 0 36px 68px rgba(0, 0, 0, 0.25);
-  overflow: hidden;
-  animation: heroFloat 10s ease-in-out infinite;
+  border: 0;
+  box-shadow: 0 32px 64px rgba(15, 105, 175, 0.18);
+  overflow: visible;
+  animation: heroFloat 12s ease-in-out infinite;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .hero__animation::before,
 .hero__animation::after {
   content: '';
   position: absolute;
-  inset: 10%;
-  border-radius: 26px;
-  border: 4px solid var(--color-vibrant-magenta);
-  transform: rotate(-6deg);
-  animation: heroOrbit 12s infinite ease-in-out;
+  border-radius: 50%;
+  background: var(--color-neutral-white);
+  opacity: 0.9;
+}
+
+.hero__animation::before {
+  width: 68%;
+  height: 68%;
+  top: 16%;
+  left: 18%;
+  box-shadow: 0 24px 48px rgba(15, 105, 175, 0.18);
+  animation: heroFloat 16s ease-in-out infinite reverse;
 }
 
 .hero__animation::after {
-  inset: 18%;
-  transform: rotate(8deg);
-  border-color: var(--color-vibrant-green);
-  animation-duration: 16s;
+  width: 46%;
+  height: 46%;
+  bottom: 18%;
+  right: 16%;
+  background: rgba(255, 255, 255, 0.8);
+  box-shadow: 0 20px 36px rgba(15, 105, 175, 0.15);
+  animation: heroFloat 20s ease-in-out infinite;
 }
 
-.hero__orbit {
-  position: absolute;
-  inset: 22%;
-  border-radius: 50%;
-  border: 4px dashed var(--color-vibrant-magenta);
-  animation: heroPulse 8s infinite ease-in-out;
+.hero__orbit,
+.hero__spark {
+  display: none;
 }
 
 .hero__orb {
   position: absolute;
-  width: 72px;
-  height: 72px;
   border-radius: 50%;
-  box-shadow: 0 18px 40px rgba(0, 0, 0, 0.25);
+  border: 2px solid rgba(255, 255, 255, 0.85);
+  background: rgba(255, 255, 255, 0.7);
+  box-shadow: 0 18px 38px rgba(15, 105, 175, 0.12);
 }
 
 .hero__orb--one {
-  top: 12%;
-  left: 18%;
-  background: var(--color-vibrant-magenta);
-  animation: heroDrift 12s infinite ease-in-out;
+  width: 140px;
+  height: 140px;
+  top: 8%;
+  left: 12%;
+  animation: heroDrift 18s infinite ease-in-out;
 }
 
 .hero__orb--two {
-  bottom: 8%;
-  right: 18%;
-  width: 56px;
-  height: 56px;
-  background: var(--color-vibrant-cyan);
-  animation: heroDrift 14s infinite ease-in-out reverse;
+  width: 110px;
+  height: 110px;
+  bottom: 12%;
+  right: 12%;
+  background: rgba(255, 255, 255, 0.6);
+  animation: heroDrift 20s infinite ease-in-out reverse;
 }
 
 .hero__orb--three {
-  top: 45%;
-  right: 6%;
-  width: 36px;
-  height: 36px;
-  background: var(--color-vibrant-green);
-  animation: heroDrift 10s infinite ease-in-out;
-}
-
-.hero__spark {
-  position: absolute;
-  inset: 30%;
-  border-radius: 24px;
-  border: 4px solid var(--color-vibrant-yellow);
-  animation: heroPulse 6s infinite ease-in-out;
+  width: 80px;
+  height: 80px;
+  bottom: 26%;
+  left: 28%;
+  background: rgba(255, 255, 255, 0.45);
+  animation: heroDrift 16s infinite ease-in-out;
 }
 
 .hero__media::after {
@@ -201,7 +207,7 @@
   position: absolute;
   inset: 12%;
   border-radius: 28px;
-  border: 2px dashed rgba(255, 255, 255, 0.35);
+  border: 2px dashed rgba(15, 105, 175, 0.18);
   animation: heroOrbit 18s linear infinite;
 }
 

--- a/src/styles/layouts/career-explorer.css
+++ b/src/styles/layouts/career-explorer.css
@@ -611,22 +611,36 @@
 
 .explorer-card-grid {
   display: grid;
-  gap: 1.5rem;
-  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
 }
 
 .explorer-card {
   position: relative;
   border-radius: 22px;
-  padding: 1.25rem 1.4rem 1.35rem;
+  padding: 1.5rem 1.6rem 1.6rem;
   background: var(--color-neutral-white);
   border: 3px solid var(--color-rich-purple);
   text-align: left;
   cursor: pointer;
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 1rem;
+  min-height: 220px;
   transition: transform 0.25s ease, box-shadow 0.25s ease, border-color 0.25s ease;
+}
+
+.explorer-card__top {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+}
+
+.explorer-card__info {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
 }
 
 .explorer-card__title {
@@ -641,8 +655,29 @@
 }
 
 .explorer-card__badge {
-  align-self: flex-start;
-  margin-top: 0.35rem;
+  margin-top: 0;
+  flex-shrink: 0;
+}
+
+.explorer-card__snapshot {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+}
+
+.explorer-card__snapshot-label {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--color-rich-blue);
+  font-weight: 700;
+}
+
+.explorer-card__description {
+  margin: 0;
+  color: var(--color-muted);
+  font-size: 0.92rem;
+  line-height: 1.55;
 }
 
 .explorer-card:hover,


### PR DESCRIPTION
## Summary
- surface each role's snapshot directly on the Career Explorer cards and rework the card layout so they feel larger and more informative
- refresh the hero banner styling to drop the gradients in favour of soft white and sensitive blue circles while keeping the typography legible on the lighter background

## Testing
- npm test -- --watchAll=false *(fails: exits when no tests are found)*

------
https://chatgpt.com/codex/tasks/task_e_68d0fca50bd0832daa86a4efd13cb6e2