### PR TITLE
Refine explorer and roadmap hero layouts

### DIFF
--- a/src/components/JobSkillsMatcher.jsx
+++ b/src/components/JobSkillsMatcher.jsx
@@ -214,6 +214,12 @@ const JobSkillsMatcher = () => {
     }
   };
 
+  const snapshotDescription = selectedJob?.description?.trim() || '';
+  const snapshotTooltipId = useMemo(
+    () => (selectedJob ? `explorer-snapshot-${selectedJob.id}` : undefined),
+    [selectedJob]
+  );
+
   return (
     <div className="page solid-bg experience-page experience-page--explorer explorer-page">
       <SiteHeader />
@@ -572,21 +578,33 @@ const JobSkillsMatcher = () => {
 
                   <div className="explorer-detail__body">
                     <div className="explorer-detail__quick-actions">
-                      <button className="chip" onClick={() => setMyPositionTitle(selectedJob.title)}>
-                        Save as My Position
+                      <button
+                        type="button"
+                        className="explorer-action"
+                        onClick={() => setMyPositionTitle(selectedJob.title)}
+                      >
+                        <span className="explorer-action__label">Save as My Position</span>
+                        <span className="explorer-action__hint">
+                          Updates your saved baseline with this role
+                        </span>
                       </button>
                       <button
-                        className="chip"
+                        type="button"
+                        className="explorer-action"
                         onClick={() =>
                           navigate('/roadmap', {
                             state: { currentTitle: selectedJob.title },
                           })
                         }
                       >
-                        Set as Current in Roadmap
+                        <span className="explorer-action__label">Set as Current in Roadmap</span>
+                        <span className="explorer-action__hint">
+                          Prefill the roadmap planner with this role
+                        </span>
                       </button>
                       <button
-                        className="chip"
+                        type="button"
+                        className="explorer-action"
                         onClick={() =>
                           navigate('/roadmap', {
                             state: {
@@ -596,14 +614,27 @@ const JobSkillsMatcher = () => {
                           })
                         }
                       >
-                        Plan as Target Role
+                        <span className="explorer-action__label">Plan as Target Role</span>
+                        <span className="explorer-action__hint">
+                          Compare strengths and gaps for this transition
+                        </span>
+                      </button>
+                      <button
+                        type="button"
+                        className="explorer-action explorer-action--snapshot"
+                        aria-describedby={snapshotTooltipId}
+                      >
+                        <span className="explorer-action__label">Role snapshot</span>
+                        <span className="explorer-action__hint">Hover or focus to preview</span>
+                        <span
+                          id={snapshotTooltipId}
+                          className="explorer-action__tooltip"
+                          role="tooltip"
+                        >
+                          {snapshotDescription || 'We are gathering a snapshot for this role.'}
+                        </span>
                       </button>
                     </div>
-
-                    <section className="explorer-detail__section">
-                      <h4>Role snapshot</h4>
-                      <p>{selectedJob.description}</p>
-                    </section>
 
                     <section className="explorer-detail__section">
                       <h4>Skill profile</h4>

--- a/src/styles/layouts/career-explorer.css
+++ b/src/styles/layouts/career-explorer.css
@@ -9,33 +9,31 @@
 }
 
 .explorer-hero__status-card {
-  background: var(--color-rich-purple);
-  border: 1px solid rgba(255, 255, 255, 0.24);
+  background: rgba(80, 50, 145, 0.06);
+  border: 1px solid rgba(80, 50, 145, 0.16);
   border-radius: 24px;
   padding: 1.75rem;
   display: flex;
   flex-direction: column;
   gap: 1.1rem;
-  backdrop-filter: blur(14px);
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
+  box-shadow: 0 16px 36px rgba(32, 24, 82, 0.12);
 }
-
 .explorer-hero__status-heading {
   display: grid;
   gap: 0.6rem;
 }
 
 .explorer-hero__status-card .experience-hero__status-label {
-  color: rgba(255, 255, 255, 0.72);
+  color: var(--muted);
 }
 
 .explorer-hero__status-card .experience-hero__status-value {
-  color: var(--color-vibrant-yellow);
+  color: var(--color-rich-purple);
   font-size: clamp(1.4rem, 2.4vw, 1.6rem);
 }
 
 .explorer-hero__status-card .experience-hero__status-text {
-  color: rgba(255, 255, 255, 0.78);
+  color: var(--muted);
   line-height: 1.6;
 }
 
@@ -46,12 +44,12 @@
   width: fit-content;
   padding: 0.35rem 0.85rem;
   border-radius: 999px;
-  background: rgba(255, 255, 255, 0.14);
+  background: rgba(80, 50, 145, 0.12);
   text-transform: uppercase;
   letter-spacing: 0.08em;
   font-size: 0.7rem;
   font-weight: 700;
-  color: var(--color-neutral-white);
+  color: var(--color-rich-purple);
 }
 
 .explorer-hero__form {
@@ -66,10 +64,12 @@
 
 .explorer-hero__field-label {
   text-transform: uppercase;
+.explorer-hero__field-label {
+  text-transform: uppercase;
   letter-spacing: 0.08em;
   font-size: 0.72rem;
   font-weight: 700;
-  color: rgba(255, 255, 255, 0.7);
+  color: var(--muted);
 }
 
 .explorer-hero__select-wrapper {
@@ -80,24 +80,24 @@
   width: 100%;
   padding: 0.6rem 0.85rem;
   border-radius: 14px;
-  border: 1px solid rgba(255, 255, 255, 0.35);
-  background: rgba(8, 3, 28, 0.68);
-  color: var(--color-neutral-white);
+  border: 1px solid rgba(80, 50, 145, 0.2);
+  background: var(--surface);
+  color: var(--color-text);
   font-weight: 600;
   letter-spacing: 0.01em;
   appearance: none;
-  backdrop-filter: blur(8px);
-  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+  box-shadow: 0 8px 20px rgba(32, 24, 82, 0.08);
 }
 
 .explorer-hero__select:hover {
-  border-color: rgba(255, 255, 255, 0.55);
+  border-color: rgba(80, 50, 145, 0.4);
 }
 
 .explorer-hero__select:focus {
   outline: none;
-  border-color: var(--color-vibrant-cyan);
-  box-shadow: 0 0 0 3px rgba(86, 229, 255, 0.32);
+  border-color: var(--color-rich-purple);
+  box-shadow: 0 0 0 3px rgba(80, 50, 145, 0.18);
 }
 
 .explorer-hero__chevron {
@@ -106,7 +106,7 @@
   top: 50%;
   width: 16px;
   height: 16px;
-  color: rgba(255, 255, 255, 0.7);
+  color: rgba(80, 50, 145, 0.7);
   transform: translateY(-50%);
   pointer-events: none;
 }
@@ -114,7 +114,7 @@
 .explorer-hero__helper {
   margin: 0;
   font-size: 0.85rem;
-  color: rgba(255, 255, 255, 0.65);
+  color: var(--muted);
 }
 
 .explorer-hero__form-actions {
@@ -149,14 +149,14 @@
   font-size: clamp(1.8rem, 2.4vw, 2.4rem);
   font-weight: 700;
   letter-spacing: -0.02em;
-  color: var(--color-neutral-white);
+  color: var(--color-rich-purple);
 }
 
 .explorer-hero__metric-label {
   text-transform: uppercase;
   letter-spacing: 0.08em;
   font-size: 0.78rem;
-  color: rgba(255, 255, 255, 0.68);
+  color: var(--muted);
 }
 
 .explorer-hero__actions {
@@ -354,96 +354,99 @@
 }
 
 .experience-hero--explorer {
-  background: linear-gradient(140deg, var(--color-rich-purple) 0%, var(--color-vibrant-magenta) 60%, var(--color-rich-purple) 100%);
+  background: var(--surface);
 }
 
-
-
-
-
-
-
 .experience-page--explorer .experience-hero {
-  border: 1px solid rgba(255, 255, 255, 0.18);
-  background: linear-gradient(140deg, var(--color-rich-purple) 0%, var(--color-vibrant-magenta) 65%, var(--color-rich-purple) 100%);
-  box-shadow: 0 34px 90px rgba(9, 4, 32, 0.55);
-  overflow: hidden;
+  border: 1px solid rgba(80, 50, 145, 0.16);
+  box-shadow: 0 36px 96px rgba(32, 24, 82, 0.16);
 }
 
 .experience-page--explorer .experience-hero::before,
 .experience-page--explorer .experience-hero::after {
   display: block;
-  filter: none;
-  opacity: 0.55;
+  opacity: 0.7;
 }
 
 .experience-page--explorer .experience-hero::before {
   width: 520px;
   height: 520px;
   top: -220px;
-  right: -160px;
-  background: radial-gradient(circle at center, rgba(255, 255, 255, 0.45) 0%, rgba(255, 255, 255, 0) 72%);
-  animation-duration: 16s;
+  right: -150px;
+  background: radial-gradient(
+    circle at center,
+    rgba(184, 195, 255, 0.55) 0%,
+    rgba(184, 195, 255, 0) 70%
+  );
 }
 
 .experience-page--explorer .experience-hero::after {
-  width: 560px;
-  height: 560px;
-  bottom: -280px;
-  left: -200px;
-  background: radial-gradient(circle at center, rgba(118, 197, 255, 0.48) 0%, rgba(255, 255, 255, 0) 74%);
-  animation-delay: 0.6s;
+  width: 400px;
+  height: 400px;
+  bottom: -220px;
+  left: -150px;
+  background: radial-gradient(
+    circle at center,
+    rgba(255, 214, 238, 0.5) 0%,
+    rgba(255, 214, 238, 0) 70%
+  );
+  animation-delay: 0.8s;
 }
 
 .experience-page--explorer .experience-hero__icon {
-  background: rgba(255, 255, 255, 0.18);
-  box-shadow: 0 18px 44px rgba(8, 3, 26, 0.42);
+  background: rgba(80, 50, 145, 0.14);
+  box-shadow: 0 18px 36px rgba(32, 24, 82, 0.18);
+  color: var(--color-rich-purple);
 }
 
 .experience-page--explorer .experience-hero__subtitle {
-  color: rgba(255, 255, 255, 0.9);
+  color: var(--muted);
 }
 
 .experience-page--explorer .experience-hero__status-card {
-  background: rgba(10, 4, 35, 0.55);
-  border: 1px solid rgba(255, 255, 255, 0.24);
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
-  color: var(--color-neutral-white);
+  background: rgba(80, 50, 145, 0.06);
+  border: 1px solid rgba(80, 50, 145, 0.16);
+  box-shadow: 0 18px 38px rgba(32, 24, 82, 0.12);
+  color: var(--color-text);
 }
 
 .experience-page--explorer .experience-hero__actions {
-  flex-direction: row;
-  flex-wrap: wrap;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
 }
 
-.experience-page--explorer .experience-hero__actions .button--inverse {
-  background: var(--color-neutral-white);
+.experience-page--explorer .experience-hero__actions .button {
+  box-shadow: 0 14px 32px rgba(32, 24, 82, 0.12);
+}
+
+.experience-page--explorer .experience-hero__actions .button--inverse,
+.experience-page--explorer .experience-hero__actions .button--ghost {
   color: var(--color-rich-purple);
-  border-color: transparent;
 }
 
 .experience-page--explorer .experience-hero__actions .button--ghost {
-  border-color: var(--color-neutral-white);
-  color: var(--color-neutral-white);
+  border-color: var(--color-rich-purple);
+  background: transparent;
 }
 
 .experience-page--explorer .chip-link {
-  background: var(--color-rich-purple);
-  border: 1px solid var(--color-neutral-white);
-  color: var(--color-neutral-white);
+  background: rgba(80, 50, 145, 0.08);
+  border: 1px dashed rgba(80, 50, 145, 0.35);
+  color: var(--color-rich-purple);
 }
 
 .experience-page--explorer .chip-link:hover {
   transform: translateY(-2px);
-  box-shadow: none;
+  box-shadow: 0 12px 28px rgba(32, 24, 82, 0.12);
+  color: var(--color-rich-purple);
+}
 }
 
 .experience-page--explorer .section-h2 {
-  color: var(--color-vibrant-magenta);
+  color: var(--color-rich-purple);
 }
 
 .experience-page--explorer .muted {
-  color: rgba(255, 255, 255, 0.85);
+  color: var(--muted);
 }
 
 
@@ -710,9 +713,91 @@
 }
 
 .explorer-detail__quick-actions {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 0.85rem;
+}
+
+.explorer-action {
+  position: relative;
   display: flex;
-  flex-wrap: wrap;
-  gap: 0.75rem;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.35rem;
+  padding: 1rem 1.1rem;
+  border-radius: 18px;
+  border: 1px solid rgba(80, 50, 145, 0.18);
+  background: var(--surface);
+  color: var(--color-rich-purple);
+  font-weight: 600;
+  text-align: left;
+  width: 100%;
+  min-height: 110px;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease,
+    background 0.2s ease;
+}
+
+.explorer-action__label {
+  font-size: 0.95rem;
+  color: var(--color-rich-purple);
+}
+
+.explorer-action__hint {
+  font-size: 0.78rem;
+  color: var(--muted);
+}
+
+.explorer-action:hover,
+.explorer-action:focus-visible {
+  transform: translateY(-2px);
+  border-color: rgba(80, 50, 145, 0.35);
+  box-shadow: 0 18px 36px rgba(32, 24, 82, 0.12);
+  background: var(--color-neutral-white);
+}
+
+.explorer-action:focus-visible {
+  outline: 3px solid var(--color-vibrant-cyan);
+  outline-offset: 3px;
+}
+
+.explorer-action__tooltip {
+  position: absolute;
+  left: 50%;
+  bottom: calc(100% + 14px);
+  transform: translate(-50%, 6px);
+  width: min(320px, 85vw);
+  padding: 0.85rem 1rem;
+  border-radius: 16px;
+  border: 1px solid rgba(80, 50, 145, 0.22);
+  background: var(--surface);
+  box-shadow: 0 20px 42px rgba(32, 24, 82, 0.16);
+  color: var(--muted);
+  font-size: 0.85rem;
+  line-height: 1.5;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.2s ease, transform 0.2s ease;
+  z-index: 5;
+}
+
+.explorer-action__tooltip::after {
+  content: '';
+  position: absolute;
+  left: 50%;
+  bottom: -8px;
+  transform: translateX(-50%) rotate(45deg);
+  width: 14px;
+  height: 14px;
+  background: var(--surface);
+  border-right: 1px solid rgba(80, 50, 145, 0.22);
+  border-bottom: 1px solid rgba(80, 50, 145, 0.22);
+}
+
+.explorer-action--snapshot:hover .explorer-action__tooltip,
+.explorer-action--snapshot:focus-visible .explorer-action__tooltip {
+  opacity: 1;
+  transform: translate(-50%, -4px);
 }
 
 .explorer-detail__section {

--- a/src/styles/layouts/career-roadmap.css
+++ b/src/styles/layouts/career-roadmap.css
@@ -1,5 +1,58 @@
 /* SPH Career Roadmap layout styles */
 
+.experience-page--roadmap .experience-hero {
+  border: 1px solid rgba(15, 105, 175, 0.16);
+  box-shadow: 0 36px 96px rgba(15, 40, 80, 0.18);
+}
+
+.experience-page--roadmap .experience-hero::before {
+  width: 500px;
+  height: 500px;
+  top: -210px;
+  right: -160px;
+  background: radial-gradient(
+    circle at center,
+    rgba(160, 210, 255, 0.55) 0%,
+    rgba(160, 210, 255, 0) 70%
+  );
+}
+
+.experience-page--roadmap .experience-hero::after {
+  width: 380px;
+  height: 380px;
+  bottom: -200px;
+  left: -140px;
+  background: radial-gradient(
+    circle at center,
+    rgba(180, 240, 210, 0.5) 0%,
+    rgba(180, 240, 210, 0) 70%
+  );
+  animation-delay: 0.9s;
+}
+
+.experience-page--roadmap .experience-hero__icon {
+  background: rgba(15, 105, 175, 0.12);
+  color: var(--color-rich-blue);
+  box-shadow: 0 18px 36px rgba(15, 40, 80, 0.18);
+}
+
+.experience-page--roadmap .experience-hero__status-card {
+  background: rgba(15, 105, 175, 0.06);
+  border: 1px solid rgba(15, 105, 175, 0.16);
+  box-shadow: 0 18px 38px rgba(15, 40, 80, 0.12);
+}
+
+.experience-page--roadmap .chip-link {
+  background: rgba(15, 105, 175, 0.08);
+  border: 1px dashed rgba(15, 105, 175, 0.35);
+  color: var(--color-rich-blue);
+}
+
+.experience-page--roadmap .chip-link:hover {
+  background: rgba(15, 105, 175, 0.12);
+  color: var(--color-rich-blue);
+}
+
 .roadmap-panel {
   margin-top: 3rem;
   background: var(--surface);

--- a/src/styles/layouts/job-skills-matcher.css
+++ b/src/styles/layouts/job-skills-matcher.css
@@ -17,6 +17,26 @@
   }
 }
 
+@keyframes heroOrbit {
+  0%,
+  100% {
+    transform: translate3d(0, 0, 0) scale(1);
+  }
+  50% {
+    transform: translate3d(6%, -4%, 0) scale(1.05);
+  }
+}
+
+@keyframes heroDrift {
+  0%,
+  100% {
+    transform: translate3d(0, 0, 0) scale(1);
+  }
+  50% {
+    transform: translate3d(-5%, 8%, 0) scale(0.97);
+  }
+}
+
 @keyframes fadeSlideUp {
   0% {
     opacity: 0;
@@ -98,38 +118,49 @@
 
 .experience-hero {
   position: relative;
-  padding: 2.75rem 2.5rem;
+  padding: clamp(2.75rem, 5vw, 3.5rem);
   border-radius: 28px;
-  border: 2px solid rgba(255, 255, 255, 0.18);
+  border: 1px solid rgba(80, 50, 145, 0.16);
   overflow: hidden;
-  background: var(--color-vibrant-magenta);
-  color: var(--color-text-inverse);
-  box-shadow: 0 30px 80px rgba(28, 12, 68, 0.35);
+  background: var(--surface);
+  color: var(--color-text);
+  box-shadow: 0 32px 88px rgba(30, 24, 72, 0.16);
+  isolation: isolate;
 }
 
 .experience-hero::before,
 .experience-hero::after {
   content: '';
   position: absolute;
-  width: 260px;
-  height: 260px;
   border-radius: 50%;
-  background: var(--color-sensitive-pink);
-  filter: blur(8px);
-  opacity: 0.42;
-  animation: experienceGlow 12s ease-in-out infinite;
+  pointer-events: none;
+  opacity: 0.85;
 }
 
 .experience-hero::before {
-  top: -90px;
-  right: -60px;
+  width: 440px;
+  height: 440px;
+  top: -200px;
+  right: -160px;
+  background: radial-gradient(
+    circle at center,
+    rgba(162, 182, 255, 0.55) 0%,
+    rgba(162, 182, 255, 0) 72%
+  );
+  animation: heroOrbit 18s ease-in-out infinite;
 }
 
 .experience-hero::after {
-  bottom: -120px;
-  left: -40px;
-  background: var(--color-sensitive-blue);
-  animation-delay: 0.5s;
+  width: 360px;
+  height: 360px;
+  bottom: -220px;
+  left: -140px;
+  background: radial-gradient(
+    circle at center,
+    rgba(255, 214, 238, 0.5) 0%,
+    rgba(255, 214, 238, 0) 70%
+  );
+  animation: heroDrift 20s ease-in-out infinite;
 }
 
 .experience-hero__header {
@@ -147,8 +178,9 @@
   width: 60px;
   height: 60px;
   border-radius: 20px;
-  background: rgba(255, 255, 255, 0.12);
-  box-shadow: 0 18px 40px rgba(0, 0, 0, 0.24);
+  background: rgba(80, 50, 145, 0.12);
+  box-shadow: 0 18px 40px rgba(32, 24, 82, 0.16);
+  color: var(--color-rich-purple);
   animation: floatPulse 6s ease-in-out infinite;
 }
 
@@ -156,13 +188,13 @@
   font-size: clamp(2rem, 3.2vw, 3rem);
   margin: 0;
   letter-spacing: -0.01em;
-  color: var(--color-vibrant-magenta);
+  color: var(--color-text-strong);
 }
 
 .experience-hero__subtitle {
   margin: 0.5rem 0 0;
   max-width: 540px;
-  color: rgba(255, 255, 255, 0.82);
+  color: var(--muted);
   font-size: 1.05rem;
 }
 
@@ -175,45 +207,46 @@
   z-index: 1;
 }
 
-
 .experience-hero__status-card {
-  background: rgba(12, 7, 28, 0.36);
-  border: 1px solid rgba(255, 255, 255, 0.18);
+  background: rgba(80, 50, 145, 0.06);
+  border: 1px solid rgba(80, 50, 145, 0.16);
   border-radius: 20px;
   padding: 1.5rem;
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.06);
+  gap: 0.65rem;
+  box-shadow: 0 16px 36px rgba(32, 24, 82, 0.08);
 }
 
 .experience-hero__status-label {
   text-transform: uppercase;
   font-size: 0.75rem;
   letter-spacing: 0.1em;
-  color: rgba(255, 255, 255, 0.72);
+  color: var(--muted);
 }
 
 .experience-hero__status-value {
   font-size: 1.2rem;
   font-weight: 700;
-  color: var(--color-sensitive-yellow);
+  color: var(--color-rich-purple);
 }
 
 .experience-hero__status-text {
   margin: 0;
-  color: rgba(255, 255, 255, 0.8);
+  color: var(--muted);
   font-size: 0.95rem;
 }
 
 .experience-hero__actions {
-  display: inline-flex;
-  flex-direction: column;
+  display: grid;
   gap: 0.85rem;
+  align-content: start;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
 }
 
 .experience-hero__actions .button {
-  width: fit-content;
+  width: 100%;
+  justify-content: center;
 }
 
 .chip,
@@ -234,13 +267,13 @@
 .chip {
   background: var(--surface);
   color: var(--color-rich-purple);
-  border: 1px solid var(--color-rich-purple);
+  border: 1px solid rgba(80, 50, 145, 0.28);
 }
 
 .chip-link {
-  background: rgba(255, 255, 255, 0.14);
-  border: 1px solid rgba(255, 255, 255, 0.22);
-  color: var(--color-text-inverse);
+  background: rgba(80, 50, 145, 0.08);
+  border: 1px dashed rgba(80, 50, 145, 0.35);
+  color: var(--color-rich-purple);
 }
 
 .chip--ghost {
@@ -265,7 +298,8 @@
 .chip-link:hover,
 .chip--ghost:hover {
   transform: translateY(-1px);
-  box-shadow: 0 14px 30px rgba(0, 0, 0, 0.16);
+  box-shadow: 0 12px 28px rgba(32, 24, 82, 0.12);
+  background: rgba(80, 50, 145, 0.1);
 }
 
 .tone-green {


### PR DESCRIPTION
## Summary
- restyled the explorer and roadmap hero sections with a neutral surface, animated circle accents, and updated status card styling
- refreshed the explorer detail quick actions to use refined buttons with a hover/focus tooltip that reveals the role snapshot content
- aligned shared explorer styles, button treatments, and roadmap hero accents with the lighter palette for a more consistent presentation

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d100ca6ed8832d8152f29d47fc22dc