### PR TITLE
Fix career explorer stylesheet syntax errors

### DIFF
--- a/src/styles/layouts/career-explorer.css
+++ b/src/styles/layouts/career-explorer.css
@@ -64,8 +64,6 @@
 
 .explorer-hero__field-label {
   text-transform: uppercase;
-.explorer-hero__field-label {
-  text-transform: uppercase;
   letter-spacing: 0.08em;
   font-size: 0.72rem;
   font-weight: 700;
@@ -438,7 +436,6 @@
   transform: translateY(-2px);
   box-shadow: 0 12px 28px rgba(32, 24, 82, 0.12);
   color: var(--color-rich-purple);
-}
 }
 
 .experience-page--explorer .section-h2 {


### PR DESCRIPTION
## Summary
- remove the duplicated `.explorer-hero__field-label` block so the hero rules parse correctly again
- drop the stray closing brace that prevented the "Browse positions" panel styles from loading

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d10568c774832d8733dd766bd5e6e2