### PR TITLE
Simplify button styling

### DIFF
--- a/src/components/CareerBoardGame.jsx
+++ b/src/components/CareerBoardGame.jsx
@@ -268,7 +268,7 @@ export default function CareerBoardGame() {
             </div>
           </div>
           <div className="page-heading-actions">
-            <Link to="/play-lab" className="btn ghost small">
+            <Link to="/play-lab" className="button button--small">
               Games Hub
             </Link>
           </div>
@@ -307,7 +307,7 @@ export default function CareerBoardGame() {
                   ))}
                 </select>
               </div>
-              <button className="btn" onClick={() => setSeed((s) => s + 1)} title="Reshuffle tie-breakers">
+              <button className="button" onClick={() => setSeed((s) => s + 1)} title="Reshuffle tie-breakers">
                 <Shuffle className="icon-xs mr-6" /> Shuffle Path
               </button>
             </div>
@@ -402,11 +402,11 @@ export default function CareerBoardGame() {
 
           {/* Actions */}
           <div className="row gap-12 mt-12">
-            <button className="btn primary row center" onClick={onRoll} disabled={finished || boardJobs.length < 2 || isMoving}>
+            <button className="button row center" onClick={onRoll} disabled={finished || boardJobs.length < 2 || isMoving}>
               <PlayCircle className="icon-xs mr-6 white" /> {finished ? 'Finished' : lastRoll ? `Roll (${lastRoll})` : 'Roll Dice'}
             </button>
             <button
-              className="btn"
+              className="button"
               onClick={() => {
                 setPosition(startIndex);
                 setTurn(0);

--- a/src/components/CareerRoadmap.jsx
+++ b/src/components/CareerRoadmap.jsx
@@ -402,10 +402,10 @@ export default function CareerRoadmap() {
               )}
             </div>
             <div className="experience-hero__actions">
-              <button type="button" className="button button--inverse" onClick={scrollToPlanner}>
+              <button type="button" className="button" onClick={scrollToPlanner}>
                 Start planning
               </button>
-              <Link to="/career-explorer" className="button button--ghost">
+              <Link to="/career-explorer" className="button">
                 Launch career explorer
               </Link>
             </div>
@@ -472,7 +472,7 @@ export default function CareerRoadmap() {
               <div className="roadmap-card-block__actions">
                 <button
                   type="button"
-                  className="button button--primary"
+                  className="button"
                   onClick={setMyPositionFromPicker}
                   disabled={!myPickerTitle}
                 >
@@ -640,7 +640,7 @@ export default function CareerRoadmap() {
                       <div className="roadmap-recommendation__actions">
                         <button
                           type="button"
-                          className="button button--ghost"
+                        className="button"
                           onClick={() => {
                             ensurePlannerCanShowJob(myPosition.title);
                             ensurePlannerCanShowJob(job.title);

--- a/src/components/GamesHub.jsx
+++ b/src/components/GamesHub.jsx
@@ -42,7 +42,7 @@ export default function GamesHub() {
                   For the displayed role, pick the correct skill from multiple choices. Quick rounds to build familiarity.
                 </p>
               </div>
-              <Link to="/play-lab/guess-skill" className="btn primary play-lab-card-cta">
+              <Link to="/play-lab/guess-skill" className="button play-lab-card-cta">
                 Play
               </Link>
             </article>
@@ -60,7 +60,7 @@ export default function GamesHub() {
                   See top skills and the function; choose which role they describe. Great for learning role signatures.
                 </p>
               </div>
-              <Link to="/play-lab/guess-role" className="btn primary play-lab-card-cta">
+              <Link to="/play-lab/guess-role" className="button play-lab-card-cta">
                 Play
               </Link>
             </article>
@@ -78,7 +78,7 @@ export default function GamesHub() {
                   Read a skill definition and pick the correct skill name. Sharpens vocabulary and expectations.
                 </p>
               </div>
-              <Link to="/play-lab/skill-quiz" className="btn primary play-lab-card-cta">
+              <Link to="/play-lab/skill-quiz" className="button play-lab-card-cta">
                 Play
               </Link>
             </article>
@@ -96,7 +96,7 @@ export default function GamesHub() {
                   Follow a board-style path of roles to see how careers progress within a function. Roll to advance and view key skills at each step.
                 </p>
               </div>
-              <Link to="/play-lab/career-board" className="btn primary play-lab-card-cta">
+              <Link to="/play-lab/career-board" className="button play-lab-card-cta">
                 Play
               </Link>
             </article>
@@ -114,7 +114,7 @@ export default function GamesHub() {
                   A grid of origin vs landing clusters. Roll or click to explore allowed transitions and see example roles in the destination.
                 </p>
               </div>
-              <Link to="/play-lab/pathway-matrix" className="btn primary play-lab-card-cta">
+              <Link to="/play-lab/pathway-matrix" className="button play-lab-card-cta">
                 Play
               </Link>
             </article>

--- a/src/components/GuessRoleGame.jsx
+++ b/src/components/GuessRoleGame.jsx
@@ -170,7 +170,7 @@ export default function GuessRoleGame() {
             </div>
           </div>
           <div className="page-heading-actions">
-            <Link to="/play-lab" className="btn ghost small">
+            <Link to="/play-lab" className="button button--small">
               Games Hub
             </Link>
           </div>
@@ -206,8 +206,8 @@ export default function GuessRoleGame() {
               <h3 className="title-md">Nice work!</h3>
               <p className="muted">Your score: {score} / {TOTAL_ROUNDS}</p>
               <div className="row gap-12">
-                <button className="btn primary" onClick={resetGame}>Play Again</button>
-                <Link to="/play-lab" className="btn">Games Hub</Link>
+                <button className="button" onClick={resetGame}>Play Again</button>
+                <Link to="/play-lab" className="button">Games Hub</Link>
               </div>
             </div>
           )}
@@ -257,7 +257,7 @@ export default function GuessRoleGame() {
 
               <div className="row gap-12 mt-12">
                 <button
-                  className="btn primary row center"
+                  className="button row center"
                   onClick={() => {
                     if (!answered) return; // answer first
                     if (round >= TOTAL_ROUNDS) {

--- a/src/components/HeroSection.jsx
+++ b/src/components/HeroSection.jsx
@@ -17,25 +17,24 @@ export default function HeroSection({
   media,
   children,
 }) {
-  const primaryAction =
-    primaryCta || { label: 'Explore SPH functions', onClick: onExplore, variant: 'primary' };
+  const primaryAction = primaryCta || { label: 'Explore SPH functions', onClick: onExplore };
   const secondaryAction = secondaryCta || null;
 
-  const renderAction = (action, fallbackVariant = 'ghost') => {
+  const renderAction = (action) => {
     if (!action) return null;
-    const { label, to, onClick, variant } = action;
-    const className = `button button--${variant || fallbackVariant}`;
+    const { label, to, onClick, className } = action;
+    const buttonClassName = ['button', className].filter(Boolean).join(' ');
 
     if (to) {
       return (
-        <Link to={to} className={className}>
+        <Link to={to} className={buttonClassName}>
           {label}
         </Link>
       );
     }
 
     return (
-      <button type="button" className={className} onClick={onClick || onExplore}>
+      <button type="button" className={buttonClassName} onClick={onClick || onExplore}>
         {label}
       </button>
     );
@@ -67,8 +66,8 @@ export default function HeroSection({
           </h1>
           <p className="hero__text">{description}</p>
           <div className="hero__actions">
-            {renderAction(primaryAction, 'primary')}
-            {renderAction(secondaryAction, 'ghost')}
+            {renderAction(primaryAction)}
+            {renderAction(secondaryAction)}
           </div>
           {children}
         </div>

--- a/src/components/HomePage.jsx
+++ b/src/components/HomePage.jsx
@@ -21,8 +21,8 @@ export default function HomePage() {
       <SiteHeader />
       <HeroSection
         onExplore={handleExplore}
-        primaryCta={{ label: 'Launch Career Explorer', to: '/career-explorer', variant: 'primary' }}
-        secondaryCta={{ label: 'Browse SPH functions', onClick: handleExplore, variant: 'ghost' }}
+        primaryCta={{ label: 'Launch Career Explorer', to: '/career-explorer' }}
+        secondaryCta={{ label: 'Browse SPH functions', onClick: handleExplore }}
       />
 
 

--- a/src/components/JobExplorerGame.jsx
+++ b/src/components/JobExplorerGame.jsx
@@ -193,7 +193,7 @@ export default function JobExplorerGame() {
             </div>
           </div>
           <div className="page-heading-actions">
-            <Link to="/play-lab" className="btn ghost small">
+            <Link to="/play-lab" className="button button--small">
               Games Hub
             </Link>
           </div>
@@ -229,8 +229,8 @@ export default function JobExplorerGame() {
               <h3 className="title-md">Great job!</h3>
               <p className="muted">Your score: {score} / {TOTAL_ROUNDS}</p>
               <div className="row gap-12">
-                <button className="btn primary" onClick={resetGame}>Play Again</button>
-                <Link to="/" className="btn">Explore Roles</Link>
+                <button className="button" onClick={resetGame}>Play Again</button>
+                <Link to="/" className="button">Explore Roles</Link>
               </div>
             </div>
           )}
@@ -292,7 +292,7 @@ export default function JobExplorerGame() {
 
               <div className="row gap-12 mt-12">
                 <button
-                  className="btn primary row center"
+                  className="button row center"
                   onClick={() => {
                     if (!answered) return; // must answer to proceed
                     if (round >= TOTAL_ROUNDS) {

--- a/src/components/JobSkillsMatcher.jsx
+++ b/src/components/JobSkillsMatcher.jsx
@@ -302,7 +302,7 @@ const JobSkillsMatcher = () => {
                 <div className="explorer-hero__form-actions">
                   <button
                     type="submit"
-                    className="button button--inverse button--small"
+                    className="button button--small"
                     disabled={!myPickerTitle}
                   >
                     Save my position
@@ -310,7 +310,7 @@ const JobSkillsMatcher = () => {
                   {myPosition && (
                     <button
                       type="button"
-                      className="button button--ghost button--small"
+                      className="button button--small"
                       onClick={handleClearMyPosition}
                     >
                       Clear saved role
@@ -319,7 +319,7 @@ const JobSkillsMatcher = () => {
                   <Link
                     to="/roadmap"
                     state={roadmapLinkState}
-                    className="button button--ghost button--small explorer-hero__roadmap"
+                    className="button button--small explorer-hero__roadmap"
                   >
                     Manage in roadmap
                   </Link>
@@ -343,18 +343,18 @@ const JobSkillsMatcher = () => {
               </div>
             </div>
             <div className="experience-hero__actions explorer-hero__actions">
-              <button type="button" className="button button--inverse" onClick={handleBrowseRoles}>
+              <button type="button" className="button" onClick={handleBrowseRoles}>
                 Browse all roles
               </button>
               <button
                 type="button"
-                className="button button--secondary"
+                className="button"
                 onClick={handleViewRecommendations}
                 disabled={!myPosition}
               >
                 View recommendations
               </button>
-              <Link to="/roadmap" className="button button--ghost">
+              <Link to="/roadmap" className="button">
                 Plan my roadmap
               </Link>
             </div>
@@ -374,7 +374,7 @@ const JobSkillsMatcher = () => {
             {myPosition && (
               <button
                 type="button"
-                className="button button--ghost button--small"
+                className="button button--small"
                 onClick={handleBrowseRoles}
               >
                 Explore all roles
@@ -416,14 +416,14 @@ const JobSkillsMatcher = () => {
                       <div className="explorer-recommendation__actions">
                         <button
                           type="button"
-                          className="button button--inverse button--small"
+                          className="button button--small"
                           onClick={() => handleOpenRecommendation(job)}
                         >
                           Inspect role
                         </button>
                         <button
                           type="button"
-                          className="button button--ghost button--small"
+                          className="button button--small"
                           onClick={() =>
                             navigate('/roadmap', {
                               state: { currentTitle: myPosition.title, targetTitle: job.title },
@@ -584,7 +584,7 @@ const JobSkillsMatcher = () => {
                         {selectedJob.division}
                       </p>
                     </div>
-                    <button className="icon-button" onClick={() => setSelectedJob(null)} aria-label="Close details">
+                    <button className="button button--icon" onClick={() => setSelectedJob(null)} aria-label="Close details">
                       <X className="icon-sm" />
                     </button>
                   </div>

--- a/src/components/PathwayMatrixBoard.jsx
+++ b/src/components/PathwayMatrixBoard.jsx
@@ -368,7 +368,7 @@ export default function PathwayMatrixBoard() {
             </div>
           </div>
           <div className="page-heading-actions">
-            <Link to="/play-lab" className="btn ghost small">
+            <Link to="/play-lab" className="button button--small">
               Games Hub
             </Link>
           </div>
@@ -386,7 +386,7 @@ export default function PathwayMatrixBoard() {
                   ))}
                 </select>
               </div>
-              <button className="btn" onClick={() => setSeed((s) => s + 1)} title="Reshuffle choice on same roll">
+              <button className="button" onClick={() => setSeed((s) => s + 1)} title="Reshuffle choice on same roll">
                 <Shuffle className="icon-xs mr-6" /> Shuffle
               </button>
               <div className="field" style={{ minWidth: 260 }}>
@@ -400,7 +400,7 @@ export default function PathwayMatrixBoard() {
               </div>
             </div>
             <div className="row gap-12 align-center">
-              <button className="btn primary row center" onClick={onRoll}>
+              <button className="button row center" onClick={onRoll}>
                 <Dice5 className="icon-xs mr-6 white" /> Roll
               </button>
               <div className="text-sm muted">Last roll: {lastRoll || '-'}</div>

--- a/src/components/SkillDefinitionQuiz.jsx
+++ b/src/components/SkillDefinitionQuiz.jsx
@@ -121,7 +121,7 @@ export default function SkillDefinitionQuiz() {
             </div>
           </div>
           <div className="page-heading-actions">
-            <Link to="/play-lab" className="btn ghost small">
+            <Link to="/play-lab" className="button button--small">
               Games Hub
             </Link>
           </div>
@@ -157,8 +157,8 @@ export default function SkillDefinitionQuiz() {
               <h3 className="title-md">Well done!</h3>
               <p className="muted">Your score: {score} / {TOTAL_ROUNDS}</p>
               <div className="row gap-12">
-                <button className="btn primary" onClick={resetGame}>Play Again</button>
-                <Link to="/play-lab" className="btn">Games Hub</Link>
+                <button className="button" onClick={resetGame}>Play Again</button>
+                <Link to="/play-lab" className="button">Games Hub</Link>
               </div>
             </div>
           )}
@@ -199,7 +199,7 @@ export default function SkillDefinitionQuiz() {
 
               <div className="row gap-12 mt-12">
                 <button
-                  className="btn primary row center"
+                  className="button row center"
                   onClick={() => {
                     if (!answered) return;
                     if (round >= TOTAL_ROUNDS) {

--- a/src/styles/components/buttons.css
+++ b/src/styles/components/buttons.css
@@ -1,7 +1,5 @@
 /*
- * Button system shared across classic .btn markup and the new BEM-friendly
- * .button component. Updated to reflect Merck's rich, vibrant, and sensitive
- * palette without gradients or tints.
+ * Unified button styles.
  */
 
 .button,
@@ -12,15 +10,29 @@
   gap: 0.5rem;
   padding: 0.625rem 1rem;
   border-radius: 14px;
-  border: 2px solid var(--color-border-soft);
+  border: 2px solid var(--color-rich-purple);
+  background: var(--color-rich-purple);
+  color: var(--color-text-inverse);
   cursor: pointer;
   font-weight: 700;
   font-size: 0.9375rem;
   letter-spacing: 0.01em;
+  text-decoration: none;
   transition: transform 0.15s ease, box-shadow 0.15s ease,
-  background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
-  background: var(--surface);
-  color: var(--color-text);
+    background 0.2s ease, color 0.2s ease;
+  box-shadow: 0 12px 30px rgba(80, 50, 145, 0.25);
+}
+
+.button:hover,
+.btn:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 18px 40px rgba(80, 50, 145, 0.35);
+}
+
+.button:focus-visible,
+.btn:focus-visible {
+  outline: 3px solid var(--color-vibrant-cyan);
+  outline-offset: 2px;
 }
 
 .button:disabled,
@@ -29,95 +41,8 @@
 .btn[aria-disabled='true'] {
   opacity: 0.6;
   cursor: not-allowed;
-}
-
-.button--primary,
-.btn.primary {
-  background: var(--color-rich-purple);
-  color: var(--color-text-inverse);
-  border-color: var(--color-rich-purple);
-  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.24);
-}
-
-.button--primary:hover,
-.btn.primary:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 18px 42px rgba(0, 0, 0, 0.28);
-}
-
-.button--primary:focus-visible,
-.btn.primary:focus-visible {
-  outline: 3px solid var(--color-vibrant-cyan);
-  outline-offset: 2px;
-}
-
-.button--secondary,
-.btn.secondary {
-  background: var(--color-vibrant-yellow);
-  color: var(--color-rich-purple);
-  border-color: var(--color-rich-purple);
-}
-
-.button--secondary:hover,
-.btn.secondary:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.18);
-}
-
-.button--ghost,
-.btn.ghost {
-  background: transparent;
-  color: var(--color-rich-purple);
-  border-color: var(--color-rich-purple);
-}
-
-.button--ghost:hover,
-.btn.ghost:hover {
-  background: var(--color-sensitive-pink);
-}
-
-.button--ghost:focus-visible,
-.btn.ghost:focus-visible {
-  outline: 3px solid var(--color-vibrant-cyan);
-  outline-offset: 2px;
-}
-
-.button--inverse {
-  background: var(--color-text-inverse);
-  color: var(--color-rich-purple);
-  border-color: transparent;
-  box-shadow: 0 22px 45px rgba(0, 0, 0, 0.28);
-}
-
-.button--inverse:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 26px 52px rgba(0, 0, 0, 0.3);
-}
-
-.button--inverse:focus-visible {
-  outline: 3px solid var(--color-vibrant-cyan);
-  outline-offset: 2px;
-}
-
-.button--fun,
-.btn.fun {
-  background: var(--color-rich-red);
-  color: var(--color-text-inverse);
-  border: 0;
-  padding: 0.65rem 1.25rem;
-  box-shadow: 0 20px 36px rgba(0, 0, 0, 0.25);
-}
-
-.button--fun:hover,
-.btn.fun:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 24px 48px rgba(0, 0, 0, 0.32);
-}
-
-.button--fun:focus-visible,
-.btn.fun:focus-visible {
-  outline: 3px solid var(--color-vibrant-yellow);
-  outline-offset: 3px;
+  transform: none;
+  box-shadow: none;
 }
 
 .button--full,
@@ -127,23 +52,21 @@
 
 .button--small,
 .btn.small {
-  padding: 0.375rem 0.75rem;
+  padding: 0.4rem 0.75rem;
   font-size: 0.8125rem;
   border-radius: 12px;
 }
 
-.icon-button {
-  background: var(--color-sensitive-blue);
-  color: var(--color-rich-purple);
-  border: 1px solid var(--color-rich-purple);
-  padding: 0.375rem 0.5rem;
+.button--icon {
+  padding: 0.375rem;
+  width: 2.25rem;
+  height: 2.25rem;
   border-radius: 12px;
-  cursor: pointer;
-  transition: background 0.2s ease, color 0.2s ease;
 }
 
-.icon-button:hover {
-  background: var(--color-sensitive-green);
+.button svg,
+.btn svg {
+  flex-shrink: 0;
 }
 
 .badge {

--- a/src/styles/layouts/career-explorer.css
+++ b/src/styles/layouts/career-explorer.css
@@ -478,40 +478,11 @@
 }
 
 .experience-page--explorer .experience-hero .button {
-  box-shadow: 0 16px 36px rgba(32, 24, 82, 0.14);
+  box-shadow: 0 16px 36px rgba(32, 24, 82, 0.18);
 }
 
-.experience-page--explorer .experience-hero .button--inverse {
-  background: var(--color-rich-purple);
-  border : var(--color-text-inverse);
-  color: var(--color-text-inverse);
-}
-
-.experience-page--explorer .experience-hero .button--inverse:hover {
+.experience-page--explorer .experience-hero .button:hover {
   box-shadow: 0 22px 48px rgba(46, 28, 112, 0.32);
-}
-
-.experience-page--explorer .experience-hero .button--secondary {
-  background: var(--color-rich-purple);
-  border-color: var(--color-text-inverse);
-  color: var(--color-text-inverse);
-}
-
-.experience-page--explorer .experience-hero .button--secondary:disabled {
-  color: rgba(80, 50, 145, 0.55);
-  border-color: rgba(80, 50, 145, 0.25);
-  background: linear-gradient(135deg, rgba(141, 89, 255, 0.12), rgba(150, 215, 210, 0.12));
-}
-
-.experience-page--explorer .experience-hero .button--ghost {
-  border-color: rgba(141, 89, 255, 0.55);
-  background: rgba(150, 215, 210, 0.16);
-  color: var(--color-rich-purple);
-}
-
-.experience-page--explorer .experience-hero .button--ghost:hover {
-  background: rgba(150, 215, 210, 0.26);
-  box-shadow: 0 18px 40px rgba(32, 24, 82, 0.16);
 }
 
 .experience-page--explorer .experience-hero .chip,
@@ -1105,15 +1076,6 @@
 
 .explorer-recommendation__actions .button {
   flex: 1 1 150px;
-}
-
-.explorer-recommendation__actions .button--ghost {
-  color: var(--color-neutral-white);
-  border-color: var(--color-neutral-white);
-}
-
-.explorer-recommendation__actions .button--ghost:hover {
-  background: rgba(255, 255, 255, 0.12);
 }
 
 .explorer-recommendation.tone-green {

--- a/src/styles/layouts/career-roadmap.css
+++ b/src/styles/layouts/career-roadmap.css
@@ -125,28 +125,11 @@
 }
 
 .experience-page--roadmap .experience-hero .button {
-  box-shadow: 0 16px 36px rgba(15, 40, 80, 0.14);
+  box-shadow: 0 16px 36px rgba(15, 40, 80, 0.18);
 }
 
-.experience-page--roadmap .experience-hero .button--inverse {
-  background: var(--color-rich-purple);
-  border-color: var(--color-text-inverse);
-  color: var(--color-text-inverse);
-}
-
-.experience-page--roadmap .experience-hero .button--inverse:hover {
-  box-shadow: var(--color-rich-purple);
-}
-
-.experience-page--roadmap .experience-hero .button--ghost {
-  border-color: var(--color-text-inverse);
-  background: var(--color-rich-purple);
-  color: var(--color-neutral-white);
-}
-
-.experience-page--roadmap .experience-hero .button--ghost:hover {
-  background: rgba(255, 255, 255, 0.22);
-  box-shadow: 0 18px 40px rgba(6, 14, 44, 0.22);
+.experience-page--roadmap .experience-hero .button:hover {
+  box-shadow: 0 18px 40px rgba(6, 14, 44, 0.26);
 }
 
 .experience-page--roadmap .experience-hero .chip,


### PR DESCRIPTION
## Summary
- replace the button component palette with a single purple style and keep compact modifiers
- update hero and feature components to rely on the shared `.button` class instead of variant-specific classes
- align explorer and roadmap layout overrides with the simplified button styling

## Testing
- `npm test -- --watchAll=false` *(fails: no tests are defined)*

------
https://chatgpt.com/codex/tasks/task_e_68d122895564832d8f39f696c1a82f13