### PR TITLE
Allow job explorer cards to show full summaries

### DIFF
--- a/src/styles/layouts/career-explorer.css
+++ b/src/styles/layouts/career-explorer.css
@@ -764,11 +764,8 @@
   color: var(--muted);
   position: relative;
   z-index: 1;
-  display: -webkit-box;
-  -webkit-box-orient: vertical;
-  -webkit-line-clamp: 3;
-  overflow: hidden;
   transition: color 0.25s ease;
+  overflow-wrap: anywhere;
 }
 
 .explorer-card:hover .explorer-card__summary,


### PR DESCRIPTION
## Summary
- remove the CSS line clamping applied to job explorer card summaries so full text stays visible
- add overflow wrapping to prevent long words from breaking the card layout

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d125a19058832d808abf87434c2e05