### PR TITLE
Allow job explorer cards to show hover summaries and refresh styling

### DIFF
--- a/src/components/JobSkillsMatcher.jsx
+++ b/src/components/JobSkillsMatcher.jsx
@@ -520,7 +520,7 @@ const JobSkillsMatcher = () => {
                         <span className="explorer-group__count">{groupedJobs[division].length} roles</span>
                       </div>
                       <div className="explorer-card-grid">
-                        {groupedJobs[division].map((job) => {
+                        {groupedJobs[division].map((job, index) => {
                           const isSelected = selectedJob && selectedJob.id === job.id;
                           const similarity = myPosition ? simScore(myPosition, job) : null;
                           const toneClass = similarity != null ? getSimilarityTone(similarity) : 'tone-neutral';
@@ -528,36 +528,41 @@ const JobSkillsMatcher = () => {
                           const summarySource = (job.description || job.objective || job.clusterDef || '')
                             .replace(/\s+/g, ' ')
                             .trim();
-                          const summaryText = summarySource.length > 0
-                            ? summarySource.length > 160
-                              ? `${summarySource.slice(0, 157).trimEnd()}…`
-                              : summarySource
-                            : '';
                           const clusterLabel = (job.cluster || '').trim();
-                          const accessibleLabel = summaryText
-                            ? `Open ${job.title}. ${summaryText}`
-                            : `Open ${job.title}`;
+                          const accessibleLabel = `Open ${job.title}`;
+                          const summaryId = summarySource
+                            ? `explorer-summary-${String(job.id ?? index).toLowerCase().replace(/[^a-z0-9]+/g, '-')}-${index}`
+                            : undefined;
 
                           return (
-                            <button
-                              key={job.id}
-                              type="button"
-                              className={`explorer-card ${toneClass} ${isSelected ? 'is-active' : ''}`}
-                              onClick={() => setSelectedJob(job)}
-                              aria-pressed={isSelected}
-                              title={`Open ${job.title}`}
-                              aria-label={accessibleLabel}
-                            >
-                              <span className="explorer-card__title">{job.title}</span>
-                              <span className="explorer-card__meta">{job.division}</span>
-                              {badge && <span className={`explorer-card__badge ${badge.color}`}>{badge.label}</span>}
-                              {clusterLabel && (
-                                <span className="explorer-card__cluster">{clusterLabel}</span>
+                            <div key={job.id} className={`explorer-card-wrapper ${summarySource ? 'has-summary' : ''}`}>
+                              <button
+                                type="button"
+                                className={`explorer-card ${toneClass} ${isSelected ? 'is-active' : ''}`}
+                                onClick={() => setSelectedJob(job)}
+                                aria-pressed={isSelected}
+                                title={`Open ${job.title}`}
+                                aria-label={accessibleLabel}
+                                {...(summaryId ? { 'aria-describedby': summaryId } : {})}
+                              >
+                                <span className="explorer-card__title">{job.title}</span>
+                                <span className="explorer-card__meta">{job.division}</span>
+                                {badge && <span className={`explorer-card__badge ${badge.color}`}>{badge.label}</span>}
+                                {clusterLabel && (
+                                  <span className="explorer-card__cluster">{clusterLabel}</span>
+                                )}
+                              </button>
+                              {summarySource && (
+                                <div
+                                  id={summaryId}
+                                  className="explorer-card__tooltip"
+                                  role="tooltip"
+                                >
+                                  <span className="explorer-card__tooltip-label">Role snapshot</span>
+                                  <p className="explorer-card__tooltip-text">{summarySource}</p>
+                                </div>
                               )}
-                              {summaryText && (
-                                <span className="explorer-card__summary">{summaryText}</span>
-                              )}
-                            </button>
+                            </div>
                           );
                         })}
                       </div>

--- a/src/styles/layouts/career-explorer.css
+++ b/src/styles/layouts/career-explorer.css
@@ -1,7 +1,7 @@
 /* SPH Career Explorer layout styles */
 
 .explorer-page {
-  background: var(--color-neutral-white);
+  background: var(--color-text-inverse);
 }
 
 .explorer-page .hero {
@@ -656,9 +656,10 @@
 .explorer-group {
   padding: 2rem;
   border-radius: 28px;
-  background: var(--color-rich-purple);
+  background: var(--color-text-inverse);
   border: 3px solid var(--color-vibrant-magenta);
-  color: var(--color-neutral-white);
+  color: var(--color-rich-purple);
+  box-shadow: 0 24px 48px rgba(32, 24, 82, 0.14);
 }
 
 .explorer-group__header {
@@ -674,12 +675,14 @@
   font-size: 1.25rem;
   font-weight: 700;
   color: var(--color-vibrant-magenta);
+  letter-spacing: 0.01em;
 }
 
 .explorer-group__count {
   font-size: 0.85rem;
   color: var(--color-vibrant-yellow);
-  font-weight: 600;
+  font-weight: 700;
+  text-shadow: 0 1px 1px rgba(20, 18, 54, 0.35);
 }
 
 .explorer-card-grid {
@@ -692,8 +695,8 @@
   position: relative;
   border-radius: 22px;
   padding: 1.25rem 1.4rem 1.35rem;
-  background: var(--color-neutral-white);
-  border: 3px solid var(--color-rich-purple);
+  background: var(--color-text-inverse);
+  border: 3px solid var(--color-vibrant-magenta);
   text-align: left;
   cursor: pointer;
   display: flex;
@@ -702,8 +705,8 @@
   min-height: 220px;
   transition: transform 0.25s ease, box-shadow 0.25s ease, border-color 0.25s ease,
     background 0.25s ease;
-  overflow: hidden;
-  z-index: 0;
+  box-shadow: 0 18px 40px rgba(32, 24, 82, 0.12);
+  z-index: 1;
 }
 
 .explorer-card::after {
@@ -711,7 +714,7 @@
   position: absolute;
   inset: 0;
   border-radius: inherit;
-  background: linear-gradient(150deg, rgba(80, 50, 145, 0.16), rgba(255, 214, 238, 0));
+  background: linear-gradient(150deg, rgba(235, 60, 150, 0.22), rgba(255, 200, 50, 0.08));
   opacity: 0;
   transform: translateY(16px) scale(0.96);
   transition: opacity 0.3s ease, transform 0.3s ease;
@@ -721,17 +724,20 @@
 
 .explorer-card__title {
   font-size: 1rem;
-  font-weight: 700;
-  color: var(--color-rich-purple);
+  font-weight: 800;
+  color: var(--color-vibrant-magenta);
   position: relative;
   z-index: 1;
+  letter-spacing: 0.01em;
 }
 
 .explorer-card__meta {
   font-size: 0.85rem;
-  color: var(--color-rich-blue);
+  color: var(--color-vibrant-yellow);
+  font-weight: 600;
   position: relative;
   z-index: 1;
+  text-shadow: 0 1px 1px rgba(20, 18, 54, 0.35);
 }
 
 .explorer-card__badge {
@@ -747,34 +753,127 @@
   align-self: flex-start;
   padding: 0.3rem 0.75rem;
   border-radius: 999px;
-  background: rgba(80, 50, 145, 0.12);
-  color: var(--color-rich-purple);
+  background: rgba(255, 200, 50, 0.18);
+  color: var(--color-vibrant-magenta);
   font-size: 0.68rem;
   letter-spacing: 0.1em;
   text-transform: uppercase;
-  font-weight: 700;
+  font-weight: 800;
   position: relative;
   z-index: 1;
+  box-shadow: inset 0 0 0 1px rgba(235, 60, 150, 0.35);
 }
 
-.explorer-card__summary {
-  margin-top: 0.6rem;
-  font-size: 0.78rem;
-  line-height: 1.5;
-  color: var(--muted);
+/** Tooltip presentation */
+.explorer-card-wrapper {
   position: relative;
-  z-index: 1;
-  display: -webkit-box;
-  -webkit-box-orient: vertical;
-  -webkit-line-clamp: 3;
-  overflow: hidden;
-  transition: color 0.25s ease;
+  display: block;
+  height: 100%;
 }
 
-.explorer-card:hover .explorer-card__summary,
-.explorer-card.is-active .explorer-card__summary,
-.explorer-card:focus-visible .explorer-card__summary {
+.explorer-card-wrapper .explorer-card {
+  width: 100%;
+}
+
+.explorer-card__tooltip {
+  position: absolute;
+  top: 0;
+  left: calc(100% + 1rem);
+  width: clamp(220px, 28vw, 320px);
+  padding: 1.1rem 1.25rem;
+  border-radius: 18px;
+  border: 3px solid var(--color-vibrant-magenta);
+  background: var(--color-text-inverse);
+  box-shadow: 0 24px 48px rgba(32, 24, 82, 0.22);
   color: var(--color-rich-purple);
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  opacity: 0;
+  transform: translateY(-8px);
+  transition: opacity 0.25s ease, transform 0.25s ease;
+  pointer-events: none;
+  z-index: 5;
+}
+
+.explorer-card__tooltip::before {
+  content: '';
+  position: absolute;
+  top: 1.4rem;
+  left: -12px;
+  width: 0;
+  height: 0;
+  border-top: 12px solid transparent;
+  border-bottom: 12px solid transparent;
+  border-right: 12px solid var(--color-vibrant-magenta);
+}
+
+.explorer-card__tooltip::after {
+  content: '';
+  position: absolute;
+  top: 1.4rem;
+  left: -9px;
+  width: 0;
+  height: 0;
+  border-top: 10px solid transparent;
+  border-bottom: 10px solid transparent;
+  border-right: 10px solid var(--color-text-inverse);
+}
+
+.explorer-card__tooltip-label {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  font-weight: 800;
+  color: var(--color-vibrant-yellow);
+  text-shadow: 0 1px 1px rgba(20, 18, 54, 0.35);
+}
+
+.explorer-card__tooltip-text {
+  margin: 0;
+  font-size: 0.82rem;
+  line-height: 1.6;
+  color: var(--color-vibrant-magenta);
+  font-weight: 600;
+  text-shadow: 0 1px 1px rgba(20, 18, 54, 0.2);
+}
+
+.explorer-card-wrapper:hover .explorer-card__tooltip,
+.explorer-card-wrapper:focus-within .explorer-card__tooltip {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+@media (max-width: 960px) {
+  .explorer-card__tooltip {
+    left: calc(100% + 0.75rem);
+    width: clamp(220px, 40vw, 280px);
+  }
+}
+
+@media (max-width: 768px) {
+  .explorer-card-wrapper {
+    position: static;
+  }
+
+  .explorer-card__tooltip {
+    position: relative;
+    top: auto;
+    left: auto;
+    width: 100%;
+    margin-top: 0.85rem;
+    transform: translateY(-10px);
+  }
+
+  .explorer-card__tooltip::before,
+  .explorer-card__tooltip::after {
+    display: none;
+  }
+
+  .explorer-card-wrapper:hover .explorer-card__tooltip,
+  .explorer-card-wrapper:focus-within .explorer-card__tooltip {
+    transform: translateY(0);
+  }
 }
 
 .explorer-card:hover,

--- a/src/styles/layouts/career-roadmap.css
+++ b/src/styles/layouts/career-roadmap.css
@@ -301,36 +301,41 @@
 }
 
 .roadmap-group {
-  border: 2px solid rgba(141, 89, 255, 0.18);
+  border: 3px solid var(--color-vibrant-magenta);
   border-radius: 22px;
   padding: 1.5rem;
-  background: rgba(255, 255, 255, 0.95);
+  background: var(--color-text-inverse);
   margin-bottom: 1.25rem;
+  box-shadow: 0 24px 48px rgba(32, 24, 82, 0.12);
 }
 
 .roadmap-group__header {
   display: flex;
   align-items: center;
   gap: 0.65rem;
-  font-weight: 700;
-  color: var(--color-rich-purple);
+  font-weight: 800;
+  color: var(--color-vibrant-magenta);
   margin-bottom: 1rem;
+  letter-spacing: 0.01em;
 }
 
 .roadmap-group__icon {
   width: 32px;
   height: 32px;
   border-radius: 12px;
-  background: rgba(141, 89, 255, 0.14);
+  background: rgba(235, 60, 150, 0.16);
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  color: var(--color-vibrant-magenta);
 }
 
 .roadmap-group__count {
   margin-left: auto;
   font-size: 0.8rem;
-  color: var(--muted);
+  color: var(--color-vibrant-yellow);
+  font-weight: 700;
+  text-shadow: 0 1px 1px rgba(20, 18, 54, 0.35);
 }
 
 .roadmap-group__grid {
@@ -341,10 +346,10 @@
 
 .roadmap-card {
   border-radius: 20px;
-  border: 1px solid rgba(141, 89, 255, 0.2);
-  background: rgba(255, 255, 255, 0.96);
+  border: 2px solid rgba(235, 60, 150, 0.28);
+  background: var(--color-text-inverse);
   padding: 1.1rem 1.25rem;
-  box-shadow: 0 12px 30px rgba(20, 30, 70, 0.12);
+  box-shadow: 0 18px 40px rgba(32, 24, 82, 0.12);
   display: flex;
   flex-direction: column;
   gap: 0.8rem;
@@ -360,18 +365,21 @@
 .roadmap-card__header h4 {
   margin: 0;
   font-size: 1rem;
-  color: var(--color-rich-purple);
+  color: var(--color-vibrant-magenta);
+  font-weight: 800;
 }
 
 .roadmap-card__range {
   font-size: 0.82rem;
-  color: var(--muted);
+  color: var(--color-vibrant-yellow);
+  font-weight: 700;
+  text-shadow: 0 1px 1px rgba(20, 18, 54, 0.35);
 }
 
 .roadmap-card__gap {
   font-size: 0.8rem;
-  font-weight: 600;
-  color: var(--color-rich-purple);
+  font-weight: 700;
+  color: var(--color-vibrant-magenta);
 }
 
 .roadmap-card__footer {
@@ -384,7 +392,8 @@
   font-size: 0.75rem;
   text-transform: uppercase;
   letter-spacing: 0.08em;
-  color: var(--muted);
+  color: var(--color-vibrant-yellow);
+  font-weight: 700;
 }
 
 .roadmap-card__training {
@@ -392,7 +401,8 @@
   align-items: center;
   gap: 0.5rem;
   font-size: 0.8rem;
-  color: var(--color-rich-purple);
+  color: var(--color-vibrant-magenta);
+  font-weight: 600;
 }
 
 .roadmap-results {
@@ -415,10 +425,10 @@
 
 .roadmap-recommendation {
   border-radius: 22px;
-  border: 1px solid rgba(141, 89, 255, 0.2);
-  background: rgba(255, 255, 255, 0.95);
+  border: 2px solid rgba(235, 60, 150, 0.28);
+  background: var(--color-text-inverse);
   padding: 1.3rem 1.5rem;
-  box-shadow: 0 16px 40px rgba(16, 26, 70, 0.14);
+  box-shadow: 0 20px 45px rgba(16, 26, 70, 0.16);
   display: flex;
   flex-direction: column;
   gap: 0.8rem;
@@ -433,9 +443,10 @@
 
 .roadmap-recommendation__summary {
   font-size: 0.85rem;
-  color: var(--color-rich-purple);
+  color: var(--color-vibrant-magenta);
   display: grid;
   gap: 0.35rem;
+  font-weight: 600;
 }
 
 .roadmap-recommendation__actions {


### PR DESCRIPTION
## Summary
- replace the inline job summary with a right-aligned hover tooltip so the full description appears without truncation
- restyle the explorer surface with `var(--color-text-inverse)` backgrounds and vibrant magenta/yellow text accents
- apply the same accent and background updates to the roadmap cards and recommendations for visual consistency

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d125a19058832d808abf87434c2e05