### PR TITLE
Create full-screen job insight canvas with comparison

### DIFF
--- a/src/components/JobInsightCanvas.jsx
+++ b/src/components/JobInsightCanvas.jsx
@@ -1,0 +1,421 @@
+// src/components/JobInsightCanvas.jsx
+import React, { useEffect, useMemo, useState } from 'react';
+import {
+  X,
+  ArrowLeft,
+  MapPin,
+  Sparkles,
+  Target,
+  Scales,
+  Layers,
+  ArrowRight,
+  Star,
+} from 'lucide-react';
+import '../styles/components/job-insight-canvas.css';
+import { classifyType, getSimilarityBadge, summarizeTransition } from '../utils/jobDataUtils';
+
+function formatSimilarity(score) {
+  if (score == null) return '—';
+  return `${score}% match`;
+}
+
+function pluralise(count, noun) {
+  return `${count} ${noun}${count === 1 ? '' : 's'}`;
+}
+
+const typeLabels = {
+  functional: 'Functional',
+  soft: 'Soft',
+  unknown: 'Additional',
+};
+
+export default function JobInsightCanvas({
+  job,
+  onClose,
+  onOpenJob,
+  onSaveMyPosition,
+  onPlanRoadmap,
+  summary,
+  highlights,
+  skillsByType,
+  baselineSimilarity,
+  matchingJobs,
+  recommendations,
+  myPosition,
+  jobs,
+  simScore,
+}) {
+  const [compareTargetId, setCompareTargetId] = useState('');
+
+  useEffect(() => {
+    setCompareTargetId('');
+  }, [job?.id]);
+
+  const compareJob = useMemo(() => {
+    if (!compareTargetId) return null;
+    return jobs.find((candidate) => String(candidate.id) === compareTargetId) || null;
+  }, [jobs, compareTargetId]);
+
+  const compareInsights = useMemo(() => {
+    if (!compareJob) return null;
+    const similarity = simScore(job, compareJob);
+    const summaryRows = summarizeTransition(job, compareJob, 6);
+    return { similarity, summaryRows };
+  }, [job, compareJob, simScore]);
+
+  const skillLadder = useMemo(() => {
+    return (job.skillOrder || [])
+      .map((name) => ({
+        name,
+        level: job.skillMap?.[name] ?? 0,
+        definition: job.skillDefByName?.[name] || '',
+        type: classifyType(job.skillTypeByName?.[name]),
+      }))
+      .sort((a, b) => {
+        if (b.level === a.level) return a.name.localeCompare(b.name);
+        return b.level - a.level;
+      })
+      .slice(0, 8);
+  }, [job]);
+
+  const skillMix = useMemo(() => {
+    const mix = {
+      functional: skillsByType?.functional?.length || 0,
+      soft: skillsByType?.soft?.length || 0,
+      unknown: skillsByType?.unknown?.length || 0,
+    };
+    const total = Math.max(1, mix.functional + mix.soft + mix.unknown);
+    return {
+      mix,
+      percentages: {
+        functional: Math.round((mix.functional / total) * 100),
+        soft: Math.round((mix.soft / total) * 100),
+        unknown: Math.round((mix.unknown / total) * 100),
+      },
+      total,
+    };
+  }, [skillsByType]);
+
+  const sharedCluster = compareJob && job.cluster && compareJob.cluster && job.cluster === compareJob.cluster;
+
+  const sharedSkills = useMemo(() => {
+    if (!compareJob) return [];
+    const shared = (job.skillOrder || []).filter((name) => compareJob.skillOrder?.includes(name));
+    return shared
+      .map((name) => ({
+        name,
+        current: job.skillMap?.[name] ?? 0,
+        target: compareJob.skillMap?.[name] ?? 0,
+      }))
+      .sort((a, b) => (b.current + b.target) / 2 - (a.current + a.target) / 2)
+      .slice(0, 6);
+  }, [job, compareJob]);
+
+  const bridgeSkills = useMemo(() => {
+    if (!compareInsights) return [];
+    return compareInsights.summaryRows.gaps.map((gap) => ({
+      ...gap,
+      displayType: typeLabels[gap.type] || 'Additional',
+    }));
+  }, [compareInsights]);
+
+  const strengths = useMemo(() => {
+    if (!compareInsights) return [];
+    return compareInsights.summaryRows.strengths.map((strength) => ({
+      ...strength,
+      displayType: typeLabels[strength.type] || 'Additional',
+    }));
+  }, [compareInsights]);
+
+  const similarityBadge = baselineSimilarity != null ? getSimilarityBadge(baselineSimilarity) : null;
+
+  const handleCompareChange = (event) => {
+    setCompareTargetId(event.target.value);
+  };
+
+  const handleOpenSimilar = (targetJob) => {
+    onOpenJob(targetJob);
+  };
+
+  const handleSetAsCurrent = () => {
+    onSaveMyPosition(job);
+  };
+
+  const handlePlanAsCurrent = () => {
+    onPlanRoadmap({ currentTitle: job.title });
+  };
+
+  const handlePlanAsTarget = () => {
+    const state = myPosition?.title
+      ? { currentTitle: myPosition.title, targetTitle: job.title }
+      : { targetTitle: job.title };
+    onPlanRoadmap(state);
+  };
+
+  return (
+    <div className="insight-overlay" role="dialog" aria-modal="true" aria-label={`Details for ${job.title}`}>
+      <div className="insight-canvas">
+        <header className="insight-canvas__hero">
+          <button className="insight-canvas__close" onClick={onClose} aria-label="Close job insight">
+            <X className="icon-sm" />
+          </button>
+          <div className="insight-canvas__eyebrow">
+            <ArrowLeft className="icon-xs" />
+            <button type="button" onClick={onClose} className="insight-link">
+              Back to explorer
+            </button>
+          </div>
+          <h2 className="insight-canvas__title">{job.title}</h2>
+          <p className="insight-canvas__meta">
+            <MapPin className="icon-xs" /> {job.division}
+          </p>
+          <div className="insight-canvas__hero-actions">
+            <button type="button" className="insight-chip" onClick={handleSetAsCurrent}>
+              <Sparkles className="icon-xs" /> Save as My Position
+            </button>
+            <button type="button" className="insight-chip" onClick={handlePlanAsCurrent}>
+              <Layers className="icon-xs" /> Roadmap: set current
+            </button>
+            <button type="button" className="insight-chip" onClick={handlePlanAsTarget}>
+              <Target className="icon-xs" /> Roadmap: set target
+            </button>
+          </div>
+          <div className="insight-canvas__summary">
+            <div className="insight-summary__item">
+              <h3>Purpose</h3>
+              <p>{summary.objective || summary.description || 'This role contributes with defined impact areas across the framework.'}</p>
+            </div>
+            {summary.cluster && (
+              <div className="insight-summary__item">
+                <h3>Cluster context</h3>
+                <p className="insight-summary__cluster">{summary.cluster}</p>
+                {summary.clusterDef && <p>{summary.clusterDef}</p>}
+              </div>
+            )}
+            <div className="insight-summary__item">
+              <h3>Snapshot</h3>
+              <ul>
+                <li>{pluralise(job.skillOrder.length, 'mapped skill')}</li>
+                {baselineSimilarity != null && <li>{formatSimilarity(baselineSimilarity)}</li>}
+                {similarityBadge && <li className={`insight-tag ${similarityBadge.color}`}>My position: {similarityBadge.label}</li>}
+              </ul>
+            </div>
+          </div>
+        </header>
+
+        <section className="insight-section">
+          <div className="insight-section__header">
+            <h3>Skill DNA focus</h3>
+            <span className="insight-highlight">{pluralise(skillMix.total, 'skill')}</span>
+          </div>
+          <div className="insight-mix">
+            {Object.keys(skillMix.mix).map((key) => (
+              <div key={key} className="insight-mix__item">
+                <div className="insight-mix__bar" aria-hidden="true">
+                  <div className={`insight-mix__fill insight-mix__fill--${key}`} style={{ width: `${skillMix.percentages[key]}%` }} />
+                </div>
+                <span className="insight-mix__label">
+                  {typeLabels[key]} · {skillMix.mix[key]} ({skillMix.percentages[key]}%)
+                </span>
+              </div>
+            ))}
+          </div>
+          {highlights.length > 0 && (
+            <div className="insight-highlight-grid">
+              {highlights.map((name) => {
+                const level = job.skillMap?.[name] ?? 0;
+                const definition = job.skillDefByName?.[name];
+                return (
+                  <article key={name} className="insight-card">
+                    <header>
+                      <h4>{name}</h4>
+                      <span className="insight-pill">
+                        <Star className="icon-xxs" /> {level}/5
+                      </span>
+                    </header>
+                    {definition && <p>{definition}</p>}
+                  </article>
+                );
+              })}
+            </div>
+          )}
+          <div className="insight-ladder">
+            {skillLadder.map((skill) => (
+              <div key={skill.name} className="insight-ladder__row">
+                <div className="insight-ladder__label">
+                  <span>{skill.name}</span>
+                  <small>{typeLabels[skill.type] || 'Additional'}</small>
+                </div>
+                <div className="insight-ladder__bar" aria-label={`${skill.name} requires level ${skill.level} of 5`}>
+                  <div className="insight-ladder__fill" style={{ width: `${(skill.level / 5) * 100}%` }} />
+                </div>
+                <span className="insight-ladder__value">{skill.level}/5</span>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <section className="insight-section">
+          <div className="insight-section__header">
+            <h3>Compare this role</h3>
+            <span className="insight-highlight">Spot gaps & overlaps</span>
+          </div>
+          <div className="insight-compare">
+            <div className="insight-compare__controls">
+              <label htmlFor="compare-select">Select another role to compare</label>
+              <select id="compare-select" value={compareTargetId} onChange={handleCompareChange}>
+                <option value="">Choose a role</option>
+                {jobs
+                  .filter((candidate) => candidate.id !== job.id)
+                  .map((candidate) => (
+                    <option key={candidate.id} value={candidate.id}>
+                      {candidate.title} · {candidate.division}
+                    </option>
+                  ))}
+              </select>
+              {compareInsights && (
+                <p className="insight-compare__score">
+                  <Scales className="icon-xs" /> {formatSimilarity(compareInsights.similarity)}
+                </p>
+              )}
+            </div>
+
+            {compareJob ? (
+              <div className="insight-compare__panes">
+                <div className="insight-compare__pane">
+                  <h4>{job.title}</h4>
+                  <p>{summary.objective || summary.description}</p>
+                </div>
+                <div className="insight-compare__delta">
+                  <ArrowRight className="icon-sm" />
+                  <p>{sharedCluster ? 'Within the same cluster' : 'Cross-cluster transition'}</p>
+                </div>
+                <div className="insight-compare__pane">
+                  <h4>{compareJob.title}</h4>
+                  <p>{compareJob.objective || compareJob.description}</p>
+                </div>
+              </div>
+            ) : (
+              <p className="insight-compare__placeholder">Pick a role to unlock overlap and gap insights.</p>
+            )}
+
+            {compareInsights && (
+              <div className="insight-compare__insights">
+                {sharedCluster ? (
+                  <div className="insight-compare__group">
+                    <h5>Shared strengths</h5>
+                    {sharedSkills.length ? (
+                      <ul>
+                        {sharedSkills.map((skill) => (
+                          <li key={skill.name}>
+                            <span>{skill.name}</span>
+                            <span>
+                              {skill.current}/5 → {skill.target}/5
+                            </span>
+                          </li>
+                        ))}
+                      </ul>
+                    ) : (
+                      <p>No overlapping skills mapped yet.</p>
+                    )}
+                    {strengths.length > 0 && (
+                      <div className="insight-callout">
+                        <h6>Transferable wins</h6>
+                        <ul>
+                          {strengths.map((item) => (
+                            <li key={item.name}>
+                              <span className="insight-pill insight-pill--soft">{item.displayType}</span>
+                              <span>{item.name}</span>
+                            </li>
+                          ))}
+                        </ul>
+                      </div>
+                    )}
+                  </div>
+                ) : (
+                  <div className="insight-compare__group">
+                    <h5>Bridge the gap</h5>
+                    {bridgeSkills.length ? (
+                      <ul>
+                        {bridgeSkills.map((item) => (
+                          <li key={item.name}>
+                            <span className="insight-pill insight-pill--soft">{item.displayType}</span>
+                            <span>{item.name}</span>
+                            <span className="insight-gap">+{item.gap.toFixed(1)} proficiency</span>
+                          </li>
+                        ))}
+                      </ul>
+                    ) : (
+                      <p>No major gaps detected for this pairing.</p>
+                    )}
+                  </div>
+                )}
+              </div>
+            )}
+          </div>
+        </section>
+
+        <section className="insight-section">
+          <div className="insight-section__header">
+            <h3>Similar moves to explore</h3>
+            <span className="insight-highlight">Powered by proficiency overlap</span>
+          </div>
+          {matchingJobs.length ? (
+            <div className="insight-scroll">
+              {matchingJobs.map((candidate) => {
+                const badge = getSimilarityBadge(candidate.similarity);
+                return (
+                  <article key={candidate.id} className="insight-card insight-card--compact">
+                    <header>
+                      <h4>{candidate.title}</h4>
+                      <span className={`insight-tag ${badge.color}`}>{badge.label}</span>
+                    </header>
+                    <p className="insight-card__meta">{candidate.division}</p>
+                    <p>
+                      {candidate.summary.strengths.length > 0 && (
+                        <span>
+                          Strengths: {candidate.summary.strengths.map((item) => item.name).join(', ')}
+                        </span>
+                      )}
+                    </p>
+                    <button type="button" className="insight-link" onClick={() => handleOpenSimilar(candidate)}>
+                      View insight
+                    </button>
+                  </article>
+                );
+              })}
+            </div>
+          ) : (
+            <p className="insight-compare__placeholder">No recommended transitions for this role yet.</p>
+          )}
+        </section>
+
+        {recommendations.length > 0 && (
+          <section className="insight-section">
+            <div className="insight-section__header">
+              <h3>Because you saved “My Position”</h3>
+              <span className="insight-highlight">Suggested next moves</span>
+            </div>
+            <div className="insight-scroll">
+              {recommendations.map((candidate) => {
+                const badge = getSimilarityBadge(candidate.similarity);
+                return (
+                  <article key={candidate.id} className="insight-card insight-card--compact">
+                    <header>
+                      <h4>{candidate.title}</h4>
+                      <span className={`insight-tag ${badge.color}`}>{badge.label}</span>
+                    </header>
+                    <p className="insight-card__meta">{candidate.division}</p>
+                    <button type="button" className="insight-link" onClick={() => handleOpenSimilar(candidate)}>
+                      Compare with {job.title}
+                    </button>
+                  </article>
+                );
+              })}
+            </div>
+          </section>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/styles/components/job-insight-canvas.css
+++ b/src/styles/components/job-insight-canvas.css
@@ -1,0 +1,432 @@
+/* src/styles/components/job-insight-canvas.css */
+.insight-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(26, 17, 51, 0.75);
+  backdrop-filter: blur(8px);
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+  overflow-y: auto;
+  padding: 3rem 1.5rem;
+  z-index: 1200;
+}
+
+.insight-canvas {
+  position: relative;
+  width: min(1120px, 100%);
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.97), rgba(80, 50, 145, 0.1));
+  border-radius: 32px;
+  border: 4px solid var(--color-vibrant-magenta);
+  box-shadow: 0 24px 64px rgba(32, 24, 82, 0.35);
+  color: #000000;
+  padding: clamp(2rem, 3vw, 3rem);
+  display: grid;
+  gap: clamp(2rem, 3vw, 3rem);
+}
+
+.insight-canvas h2,
+.insight-canvas h3,
+.insight-canvas h4,
+.insight-canvas h5,
+.insight-canvas h6 {
+  color: var(--color-vibrant-magenta);
+  font-weight: 700;
+}
+
+.insight-canvas p,
+.insight-canvas li,
+.insight-canvas span {
+  color: #000000;
+}
+
+.insight-canvas__close {
+  position: absolute;
+  top: 1.2rem;
+  right: 1.2rem;
+  border: none;
+  background: var(--color-vibrant-yellow);
+  color: var(--color-rich-purple);
+  border-radius: 999px;
+  width: 38px;
+  height: 38px;
+  display: grid;
+  place-items: center;
+  cursor: pointer;
+  box-shadow: 0 6px 18px rgba(80, 50, 145, 0.25);
+}
+
+.insight-canvas__close:hover,
+.insight-canvas__close:focus-visible {
+  transform: translateY(-2px);
+}
+
+.insight-canvas__hero {
+  display: grid;
+  gap: 1rem;
+}
+
+.insight-canvas__eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  color: var(--color-vibrant-magenta);
+  font-weight: 600;
+}
+
+.insight-link {
+  background: transparent;
+  border: none;
+  padding: 0;
+  font-weight: 700;
+  color: var(--color-vibrant-magenta);
+  cursor: pointer;
+  text-decoration: underline;
+}
+
+.insight-canvas__title {
+  font-size: clamp(2rem, 4vw, 2.8rem);
+  margin: 0;
+}
+
+.insight-canvas__meta {
+  display: inline-flex;
+  gap: 0.35rem;
+  align-items: center;
+  font-weight: 600;
+  background: rgba(235, 60, 150, 0.15);
+  padding: 0.35rem 0.8rem;
+  border-radius: 999px;
+}
+
+.insight-canvas__hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+}
+
+.insight-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  border-radius: 999px;
+  padding: 0.45rem 0.9rem;
+  border: 2px solid var(--color-rich-purple);
+  background: var(--color-neutral-white);
+  color: #000000;
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.insight-chip:hover,
+.insight-chip:focus-visible {
+  background: var(--color-vibrant-yellow);
+}
+
+.insight-canvas__summary {
+  display: grid;
+  gap: 1.25rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.insight-summary__item {
+  background: rgba(255, 255, 255, 0.9);
+  border-radius: 24px;
+  border: 2px solid rgba(80, 50, 145, 0.25);
+  padding: 1.25rem;
+  box-shadow: 0 12px 32px rgba(32, 24, 82, 0.15);
+}
+
+.insight-summary__item ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.45rem;
+}
+
+.insight-summary__cluster {
+  font-size: 0.95rem;
+  font-weight: 700;
+}
+
+.insight-highlight,
+.insight-pill,
+.insight-tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.3rem 0.75rem;
+  border-radius: 999px;
+  background: var(--color-vibrant-yellow);
+  color: #000000;
+  font-size: 0.78rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.insight-tag.badge.solid.green {
+  background: var(--color-rich-green);
+  color: var(--color-neutral-white);
+}
+
+.insight-tag.badge.solid.yellow {
+  background: var(--color-vibrant-yellow);
+  color: #000000;
+}
+
+.insight-tag.badge.solid.orange {
+  background: var(--color-rich-red);
+  color: var(--color-neutral-white);
+}
+
+.insight-tag.badge.solid.purple {
+  background: var(--color-rich-purple);
+  color: var(--color-neutral-white);
+}
+
+.insight-section {
+  background: rgba(255, 255, 255, 0.92);
+  border-radius: 28px;
+  border: 3px solid rgba(80, 50, 145, 0.18);
+  padding: clamp(1.6rem, 3vw, 2.4rem);
+  box-shadow: 0 18px 48px rgba(32, 24, 82, 0.18);
+  display: grid;
+  gap: 1.5rem;
+}
+
+.insight-section__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.insight-mix {
+  display: grid;
+  gap: 1rem;
+}
+
+.insight-mix__bar {
+  width: 100%;
+  height: 12px;
+  border-radius: 999px;
+  background: rgba(80, 50, 145, 0.15);
+  overflow: hidden;
+}
+
+.insight-mix__fill {
+  height: 100%;
+  border-radius: 999px;
+}
+
+.insight-mix__fill--functional {
+  background: linear-gradient(90deg, var(--color-vibrant-magenta), rgba(235, 60, 150, 0.35));
+}
+
+.insight-mix__fill--soft {
+  background: linear-gradient(90deg, var(--color-vibrant-yellow), rgba(255, 200, 50, 0.35));
+}
+
+.insight-mix__fill--unknown {
+  background: linear-gradient(90deg, var(--color-sensitive-blue), rgba(150, 215, 210, 0.35));
+}
+
+.insight-mix__label {
+  font-size: 0.9rem;
+  font-weight: 600;
+}
+
+.insight-highlight-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+}
+
+.insight-card {
+  background: var(--color-neutral-white);
+  border-radius: 20px;
+  border: 2px solid rgba(80, 50, 145, 0.22);
+  padding: 1.2rem;
+  display: grid;
+  gap: 0.6rem;
+  box-shadow: 0 16px 32px rgba(32, 24, 82, 0.16);
+}
+
+.insight-card header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.insight-card--compact {
+  min-width: 220px;
+}
+
+.insight-card__meta {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--color-rich-purple);
+}
+
+.insight-scroll {
+  display: grid;
+  gap: 1rem;
+  grid-auto-flow: column;
+  grid-auto-columns: minmax(240px, 1fr);
+  overflow-x: auto;
+  padding-bottom: 0.5rem;
+}
+
+.insight-ladder {
+  display: grid;
+  gap: 0.65rem;
+}
+
+.insight-ladder__row {
+  display: grid;
+  grid-template-columns: minmax(160px, 1fr) minmax(0, 1fr) auto;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.insight-ladder__label span {
+  font-weight: 600;
+}
+
+.insight-ladder__label small {
+  font-size: 0.75rem;
+  color: rgba(0, 0, 0, 0.6);
+}
+
+.insight-ladder__bar {
+  position: relative;
+  width: 100%;
+  height: 12px;
+  background: rgba(80, 50, 145, 0.12);
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.insight-ladder__fill {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(90deg, var(--color-vibrant-magenta), var(--color-sensitive-blue));
+  border-radius: 999px;
+}
+
+.insight-ladder__value {
+  font-weight: 700;
+}
+
+.insight-compare {
+  display: grid;
+  gap: 1.25rem;
+}
+
+.insight-compare__controls {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.insight-compare__controls select {
+  padding: 0.65rem 0.9rem;
+  border-radius: 16px;
+  border: 2px solid var(--color-rich-purple);
+  font-weight: 600;
+  background: var(--color-neutral-white);
+  color: #000000;
+}
+
+.insight-compare__score {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-weight: 700;
+}
+
+.insight-compare__panes {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  align-items: center;
+}
+
+.insight-compare__pane {
+  background: rgba(235, 60, 150, 0.08);
+  border-radius: 20px;
+  padding: 1.1rem;
+}
+
+.insight-compare__delta {
+  display: grid;
+  place-items: center;
+  padding: 1rem;
+  background: rgba(80, 50, 145, 0.1);
+  border-radius: 18px;
+  text-align: center;
+  font-weight: 700;
+}
+
+.insight-compare__placeholder {
+  font-style: italic;
+  color: rgba(0, 0, 0, 0.7);
+}
+
+.insight-compare__insights {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.insight-compare__group ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.55rem;
+}
+
+.insight-compare__group li {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  background: rgba(255, 255, 255, 0.8);
+  border-radius: 16px;
+  padding: 0.65rem 0.9rem;
+  border: 1px solid rgba(80, 50, 145, 0.12);
+}
+
+.insight-callout {
+  margin-top: 1rem;
+  border-radius: 18px;
+  background: rgba(255, 200, 50, 0.18);
+  padding: 1rem;
+  border: 2px dashed var(--color-vibrant-magenta);
+}
+
+.insight-pill--soft {
+  background: rgba(255, 200, 50, 0.8);
+}
+
+.insight-gap {
+  font-weight: 700;
+  color: var(--color-rich-purple);
+}
+
+@media (max-width: 768px) {
+  .insight-canvas {
+    padding: 2rem 1.5rem;
+  }
+
+  .insight-scroll {
+    grid-auto-columns: minmax(200px, 82vw);
+  }
+
+  .insight-ladder__row {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
## Summary
- replace the explorer sidebar with a full-screen JobInsightCanvas overlay that reuses existing dataset utilities
- add comparison workflows that surface skill DNA, proficiency ladders, and cross-cluster gap guidance for any two roles
- style the insight canvas with a white-and-purple treatment, magenta headings, and yellow highlight pills to match the updated brief

## Testing
- npm test -- --watchAll=false --passWithNoTests

------
https://chatgpt.com/codex/tasks/task_e_68d44cfa6038832da7aaa00617099bd4