### PR TITLE
Move job insight view into bottom panel

### DIFF
--- a/src/components/JobSkillsMatcher.jsx
+++ b/src/components/JobSkillsMatcher.jsx
@@ -35,6 +35,7 @@ const JobSkillsMatcher = () => {
   const filtersRef = useRef(null);
   const recommendationsRef = useRef(null);
   const resultsRef = useRef(null);
+  const insightRef = useRef(null);
 
   const [myPositionTitle, setMyPositionTitle] = useState(() => {
     if (typeof window === 'undefined') return '';
@@ -156,6 +157,12 @@ const JobSkillsMatcher = () => {
 
   useEffect(() => {
     setDetailView('overview');
+  }, [selectedJob]);
+
+  useEffect(() => {
+    if (selectedJob && insightRef.current) {
+      insightRef.current.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    }
   }, [selectedJob]);
 
   useRevealOnScroll(
@@ -626,6 +633,7 @@ const JobSkillsMatcher = () => {
           </section>
           {selectedJob && (
             <JobInsightCanvas
+              ref={insightRef}
               job={selectedJob}
               onClose={handleCloseJob}
               onOpenJob={handleOpenJob}

--- a/src/styles/components/job-insight-canvas.css
+++ b/src/styles/components/job-insight-canvas.css
@@ -1,15 +1,23 @@
 /* src/styles/components/job-insight-canvas.css */
-.insight-overlay {
-  position: fixed;
-  inset: 0;
-  background: rgba(26, 17, 51, 0.75);
-  backdrop-filter: blur(8px);
+.insight-panel {
+  position: relative;
+  width: 100%;
   display: flex;
   justify-content: center;
-  align-items: flex-start;
-  overflow-y: auto;
-  padding: 3rem 1.5rem;
-  z-index: 1200;
+  align-items: stretch;
+  padding: clamp(2rem, 4vw, 3rem) clamp(1.5rem, 4vw, 3rem) clamp(2.5rem, 5vw, 4rem);
+  padding-bottom: calc(clamp(2.5rem, 5vw, 4rem) + env(safe-area-inset-bottom, 0px));
+  margin-inline: auto;
+  margin-top: clamp(2rem, 4vw, 3.5rem);
+  background: linear-gradient(
+    180deg,
+    rgba(26, 17, 51, 0.02) 0%,
+    rgba(26, 17, 51, 0.08) 55%,
+    rgba(26, 17, 51, 0.16) 100%
+  );
+  border-top: 1px solid rgba(80, 50, 145, 0.12);
+  box-shadow: 0 -24px 48px rgba(32, 24, 82, 0.08);
+  scroll-margin-top: clamp(6rem, 12vw, 8rem);
 }
 
 .insight-canvas {
@@ -418,6 +426,12 @@
 }
 
 @media (max-width: 768px) {
+  .insight-panel {
+    padding: 1.75rem 1rem 2.75rem;
+    padding-bottom: calc(2.75rem + env(safe-area-inset-bottom, 0px));
+    margin-top: 1.5rem;
+  }
+
   .insight-canvas {
     padding: 2rem 1.5rem;
   }


### PR DESCRIPTION
## Summary
- convert the job insight overlay into a bottom-of-page panel that retains the existing insight content
- update the job explorer to focus the new panel when a role is selected for easier discovery
- refresh the insight panel styles for the embedded layout and add responsive padding tweaks

## Testing
- CI=true npm test -- --watch=false --passWithNoTests

------
https://chatgpt.com/codex/tasks/task_e_68d4ccfb6660832da9b13845c229163f